### PR TITLE
emacs: define bug-reference-url-format

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,3 @@
+((nil
+  (bug-reference-bug-regexp . "#\\(?2:[0-9]+\\)")
+  (bug-reference-url-format . "https://github.com/mgeisler/version-sync/issues/%s")))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["version"]
 categories = ["development-tools", "rust-patterns"]
 license = "MIT"
+exclude = [".dir-locals.el"]
 
 [dependencies]
 pulldown-cmark = { version = "0.0.11", default-features = false }


### PR DESCRIPTION
This lets Emacs highlight issue numbers and link them back to the
GitHub repository.