### PR TITLE
readme: fix 0.2.0 release date

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ error: test failed
 
 This is a changelog describing the most important changes per release.
 
-### Version 0.2.0 — September 19th, 2017
+### Version 0.2.0 — September 20th, 2017
 
 Added `assert_html_root_url_updated!` which will check that the
 `html_root_url` attribute points to the correct version of the crate


### PR DESCRIPTION
It seems that crates.io use the local time of the upload as the date
of the release. Version 0.2.0 was uploaded just before midnight on the
19th of September UTC, but just after midnight if you use my local
timezone which is CEST.