### PR TITLE
is_toml_block: skip blocks with no_sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ error: test failed
 
 This is a changelog describing the most important changes per release.
 
+### Unreleased
+
+When checking dependencies in READMEs, TOML blocks can now be excluded
+from the check by adding `no_sync` to the language line:
+
+    ```toml,no_sync
+    [dependencies]
+    your_crate = "0.1"
+    ```
+
+This TOML block will not be checked. This is similar to `no_run` for
+Rust code blocks.
+
 ### Version 0.2.0 — September 20th, 2017
 
 Added `assert_html_root_url_updated!` which will check that the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -492,12 +492,12 @@ mod tests {
 
     #[test]
     fn is_toml_block_simple() {
-        assert!(!is_toml_block("rust"))
+        assert!(!is_toml_block("rust"));
     }
 
     #[test]
     fn is_toml_block_comma() {
-        assert!(is_toml_block("foo,toml"))
+        assert!(is_toml_block("foo,toml"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,8 +179,15 @@ fn extract_version_request(pkg_name: &str, block: &str) -> Result<VersionReq> {
 fn is_toml_block(lang: &str) -> bool {
     // Split the language line as LangString::parse from rustdoc:
     // https://github.com/rust-lang/rust/blob/1.20.0/src/librustdoc/html/markdown.rs#L922
-    lang.split(|c: char| !(c == '_' || c == '-' || c.is_alphanumeric()))
-        .any(|token| token.trim() == "toml")
+    let mut has_toml = false;
+    for token in lang.split(|c: char| !(c == '_' || c == '-' || c.is_alphanumeric())) {
+        match token.trim() {
+            "no_sync" => return false,
+            "toml" => has_toml = true,
+            _ => {}
+        }
+    }
+    has_toml
 }
 
 /// Find all TOML code blocks in a Markdown text.
@@ -491,6 +498,12 @@ mod tests {
     #[test]
     fn is_toml_block_comma() {
         assert!(is_toml_block("foo,toml"))
+    }
+
+    #[test]
+    fn is_toml_block_no_sync() {
+        assert!(!is_toml_block("toml,no_sync"));
+        assert!(!is_toml_block("toml, no_sync"));
     }
 
     mod test_version_matches_request {


### PR DESCRIPTION
Similarly to how you can use no_run to exclude a block with Rust code
from being executed by rustdoc, you can now use no_sync to exclude
TOML blocks from being checked by the check_markdown_deps function.