### PR TITLE
travis: remove commands that are default anyway

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ rust:
 
 cache: cargo
 
-script:
-  - cargo build --verbose
-  - cargo test --verbose
-
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
The `script` commands specified here are the default commands. So we can leave them out.