### PR TITLE
Document no_sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,10 +102,12 @@ error: test failed
 You can add `no_sync` to the language line in a code block to exclude
 it from the checks done by `assert_markdown_deps_updated!`:
 
-    ```toml,no_sync
-    [dependencies]
-    your_crate = "0.1.2"
-    ```
+~~~markdown
+```toml,no_sync
+[dependencies]
+your_crate = "0.1.2"
+```
+~~~
 
 ## Release History
 
@@ -116,10 +118,12 @@ This is a changelog describing the most important changes per release.
 When checking dependencies in READMEs, TOML blocks can now be excluded
 from the check by adding `no_sync` to the language line:
 
-    ```toml,no_sync
-    [dependencies]
-    your_crate = "0.1"
-    ```
+~~~markdown
+```toml,no_sync
+[dependencies]
+your_crate = "0.1"
+```
+~~~
 
 This TOML block will not be checked. This is similar to `no_run` for
 Rust code blocks.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,16 @@ test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured
 error: test failed
 ```
 
+### Excluding TOML Code
+
+You can add `no_sync` to the language line in a code block to exclude
+it from the checks done by `assert_markdown_deps_updated!`:
+
+    ```toml,no_sync
+    [dependencies]
+    your_crate = "0.1.2"
+    ```
+
 ## Release History
 
 This is a changelog describing the most important changes per release.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,30 @@ fn find_toml_blocks(text: &str) -> Vec<CodeBlock> {
 /// dependencies on `pkg_name` in those blocks. A code block fails the
 /// check if it has a dependency on `pkg_name` that doesn't match
 /// `pkg_version`, or if it has no dependency on `pkg_name` at all.
-/// Code blocks also fails the check if they cannot be parsed as TOML.
+///
+/// # Examples
+///
+/// Consider a package named `foo` with version 1.2.3. The following
+/// TOML block will pass the test:
+///
+/// ~~~markdown
+/// ```toml
+/// [dependencies]
+/// foo = "1.2.3"
+/// ```
+/// ~~~
+///
+/// Both `dependencies` and `dev-dependencies` are examined. If you
+/// want to skip a block, add `no_sync` to the language line:
+///
+/// ~~~markdown
+/// ```toml,no_sync
+/// [dependencies]
+/// foo = "1.2.3"
+/// ```
+/// ~~~
+///
+/// Code blocks also fail the check if they cannot be parsed as TOML.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
This updates the docstrings and the README to mention the `no_sync` flag.