### PR TITLE
version_matches_request: consider pre-release identifiers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,4 @@ url = "1.5.1"
 # unicode-bidi is an indirect dependency and version 0.3.4 is not
 # compatible with Rust 1.15.0:
 unicode-bidi = "0.3.1, < 0.3.4"
+itertools = "0.6.3"

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ your_crate = "0.1.2"
 
 This is a changelog describing the most important changes per release.
 
+### Unreleased
+
+Issues closed:
+
+* [#19][issue-19]: Pre-release identifiers were ignored.
+
 ### Version 0.3.0 — September 23rd, 2017
 
 When checking dependencies in READMEs, TOML blocks can now be excluded
@@ -151,3 +157,4 @@ Contributions will be accepted under the same license.
 [travis-ci]: https://travis-ci.org/mgeisler/version-sync
 [appveyor]: https://ci.appveyor.com/project/mgeisler/version-sync
 [mit]: LICENSE
+[issue-19]: https://github.com/mgeisler/version-sync/issues/19

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,10 +112,7 @@ fn read_file(path: &str) -> std::io::Result<String> {
 
 /// Indent every line in text by four spaces.
 fn indent(text: &str) -> String {
-    text.lines()
-        .map(|line| String::from("    ") + line)
-        .collect::<Vec<_>>()
-        .join("\n")
+    join(text.lines().map(|line| String::from("    ") + line), "\n")
 }
 
 /// Verify that the version range request matches the given version.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@
 #![doc(html_root_url = "https://docs.rs/version-sync/0.3.0")]
 #![deny(missing_docs)]
 
+extern crate itertools;
 extern crate pulldown_cmark;
 extern crate semver_parser;
 extern crate syntex_syntax as syntax;
@@ -66,6 +67,7 @@ use semver_parser::version::parse as parse_version;
 use syntax::parse::{ParseSess, parse_crate_attrs_from_source_str};
 use toml::Value;
 use url::Url;
+use itertools::join;
 
 /// The common result type, our errors will be simple strings.
 type Result<T> = result::Result<T, String>;
@@ -146,6 +148,11 @@ fn version_matches_request(version: &Version, request: &VersionReq) -> Result<()
                                        version.patch,
                                        patch));
                 }
+            }
+            if pred.pre != version.pre {
+                return Err(format!("expected pre-release {:?}, found {:?}",
+                                   join(&version.pre, "."),
+                                   join(&pred.pre, ".")));
             }
         }
         _ => return Ok(()), // We cannot check other operators.
@@ -604,6 +611,14 @@ mod tests {
             let request = parse_request("1.2.3").unwrap();
             assert_eq!(version_matches_request(&version, &request),
                        Err(String::from("expected patch version 4, found 3")));
+        }
+
+        #[test]
+        fn bad_pre_release() {
+            let version = parse_version("1.2.3-rc2").unwrap();
+            let request = parse_request("1.2.3-rc1").unwrap();
+            assert_eq!(version_matches_request(&version, &request),
+                       Err(String::from("expected pre-release \"rc2\", found \"rc1\"")));
         }
     }
 


### PR DESCRIPTION
Before we completely ignored the pre-release identifiers when
comparing versions. This meant that a TOML block with

    [dependencies]
    foo = 1.0.0

was considered to match a crate version of 1.0.0-rc1. That was not
intended: per the semver specification, a pre-release version comes
before the normal version. So depending on version 1.0.0 would not
actually make it possible to install version 1.0.0-rc1.

Fixes #19.