### PR TITLE
lib: remove Syntex dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 /target/
 Cargo.lock
 *~
+**/*.rs.bk
+[._]*.sw?
+[._]sw?

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [".dir-locals.el"]
 [dependencies]
 pulldown-cmark = { version = "0.0.11", default-features = false }
 semver-parser = "0.7"
-syntex_syntax = "0.58.0"
+syn = { version = "0.11", features = ["full"] }
 toml = "0.4"
 url = "1.5.1"
 # unicode-bidi is an indirect dependency and version 0.3.4 is not

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ note: Run with `RUST_BACKTRACE=1` for a backtrace.
 
 ---- test_html_root_url stdout ----
 	Checking doc attributes in src/lib.rs...
-src/lib.rs (line 48) ... expected minor version 2, found 1 in
+src/lib.rs ... expected minor version 2, found 1 in
     #![doc(html_root_url = "https://docs.rs/version-sync/0.1.3")]
 
 thread 'test_html_root_url' panicked at 'html_root_url errors in src/lib.rs', tests/version-numbers.rs:11

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,7 +433,8 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
 
                     match check_result {
                         Ok(()) => {
-                            // FIXME
+                            // FIXME: re-add line numbers and position in line when `syn` will have
+                            // enough capabilities to do so
                             println!("{} ... ok", path);
                             return Ok(());
                         },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 extern crate itertools;
 extern crate pulldown_cmark;
 extern crate semver_parser;
-extern crate syntex_syntax as syntax;
+extern crate syn;
 extern crate toml;
 extern crate url;
 
@@ -64,7 +64,6 @@ use semver_parser::range::parse as parse_request;
 use semver_parser::range::{VersionReq, Op};
 use semver_parser::version::Version;
 use semver_parser::version::parse as parse_version;
-use syntax::parse::{ParseSess, parse_crate_attrs_from_source_str};
 use toml::Value;
 use url::Url;
 use itertools::join;
@@ -400,49 +399,55 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
     let version = parse_version(pkg_version)
         .map_err(|err| format!("bad package version {:?}: {}", pkg_version, err))?;
 
-    let session = ParseSess::new();
-    // The parse_crate_attrs_from_source_str function panics if the
-    // source code couldn't be parsed, so map_err is never called.
-    let attrs = parse_crate_attrs_from_source_str(path.to_owned(), code, &session)
-        .map_err(|err| format!("could not parse {}: {:?}", path, err))?;
+    let krate = syn::parse_crate(&code)
+        .map_err(|source| format!("could not parse {} with source:\n{}", path, source))?;
 
     println!("Checking doc attributes in {}...", path);
-    let mut failed = false;
-    for attr in attrs {
-        if !attr.check_name("doc") {
-            continue;
-        }
-        if let Some(meta_items) = attr.meta_item_list() {
-            for item in meta_items {
-                if let Some(name) = item.name() {
-                    if name != "html_root_url" {
-                        continue;
-                    }
-
-                    let codemap = session.codemap();
-                    let loc = codemap.lookup_char_pos(item.span.lo);
-                    let result =
-                        item.value_str()
-                            .ok_or(String::from("html_root_url attribute without URL"))
-                            .and_then(|url| url_matches(&url.as_str(), pkg_name, &version));
-                    match result {
-                        Ok(_) => println!("{} (line {}) ... ok", path, loc.line),
-                        Err(err) => {
-                            failed = true;
-                            println!("{} (line {}) ... {} in", path, loc.line, err);
-                            if let Ok(snippet) = codemap.span_to_snippet(attr.span) {
-                                println!("{}\n", indent(&snippet));
+    for attr in krate.attrs {
+        match attr {
+            syn::Attribute {
+                style: syn::AttrStyle::Inner,
+                value: syn::MetaItem::List(ref ident, ref nested_meta_items),
+                is_sugared_doc: false,
+            } if ident.as_ref() == "doc" => {
+                for nested_meta_item in nested_meta_items {
+                    let check_result = match *nested_meta_item {
+                        syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref name, ref value))
+                            if name == "html_root_url" =>
+                        {
+                            match *value {
+                                // accept both cooked and raw strings here
+                                syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
+                                // non-string html_root_url is probably an error, but we leave
+                                // this check to compiler
+                                _ => continue,
                             }
-                        }
+                        },
+                        syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref name))
+                            if name == "html_root_url" =>
+                        {
+                            Err(String::from("html_root_url attribute without URL"))
+                        },
+                        _ => continue,
+                    };
+
+                    match check_result {
+                        Ok(()) => {
+                            // FIXME
+                            println!("{} ... ok", path);
+                            return Ok(());
+                        },
+                        Err(err) => {
+                            println!("{} ... {}", path, err);
+                            return Err(format!("html_root_url errors in {}", path));
+                        },
                     }
                 }
-            }
+            },
+            _ => continue,
         }
     }
 
-    if failed {
-        return Err(format!("html_root_url errors in {}", path));
-    }
     Ok(())
 }
 


### PR DESCRIPTION
It's a big dependency, slow to compile and not maintained anymore.
Moving to `syn`.

There is a caveat though: `version-sync` relied on span information
gathered from `syntex` to provide more helpful messages. `syn` 0.11.11
doesn't have such a functionality, though there are plans to incorporate
recent changes in procedural macro system to enable spans there too.
Current `syn` master contains such code, but is unstable.