### PR TITLE
Refactor check_html_root_url

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -419,9 +419,13 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
         }
 
         for nested_meta_item in nested_meta_items {
-            let check_result = match *nested_meta_item {
-                syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref name, ref value))
-                    if name == "html_root_url" => {
+            let meta_item = match *nested_meta_item {
+                syn::NestedMetaItem::MetaItem(ref meta_item) => meta_item,
+                _ => continue,
+            };
+
+            let check_result = match *meta_item {
+                syn::MetaItem::NameValue(ref name, ref value) if name == "html_root_url" => {
                     match *value {
                         // accept both cooked and raw strings here
                         syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
@@ -430,8 +434,7 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
                         _ => continue,
                     }
                 }
-                syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref name))
-                    if name == "html_root_url" => {
+                syn::MetaItem::Word(ref name) if name == "html_root_url" => {
                     Err(String::from("html_root_url attribute without URL"))
                 }
                 _ => continue,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,10 +427,11 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
             let check_result = match *meta_item {
                 syn::MetaItem::NameValue(ref name, ref value) if name == "html_root_url" => {
                     match *value {
-                        // accept both cooked and raw strings here
+                        // Accept both cooked and raw strings here.
                         syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
-                        // non-string html_root_url is probably an
-                        // error, but we leave this check to compiler
+                        // A non-string html_root_url is probably an
+                        // error, but we leave this check to the
+                        // compiler.
                         _ => continue,
                     }
                 }
@@ -443,8 +444,8 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
             match check_result {
                 Ok(()) => {
                     // FIXME: re-add line numbers and position in line
-                    // when `syn` will have enough capabilities to do
-                    // so
+                    // when the syn crate have enough capabilities to
+                    // do so.
                     println!("{} ... ok", path);
                     return Ok(());
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,41 +414,40 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
             _ => continue,
         };
 
-        if ident.as_ref() == "doc" {
-            for nested_meta_item in nested_meta_items {
-                let check_result = match *nested_meta_item {
-                    syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref name,
-                                                                           ref value)) if name == "html_root_url" => {
-                        {
-                            {
-                                match *value {
-                                    // accept both cooked and raw strings here
-                                    syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
-                                    // non-string html_root_url is probably an error, but we leave
-                                    // this check to compiler
-                                    _ => continue,
-                                }
-                            }
-                        }
-                    }
-                    syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref name))
-                        if name == "html_root_url" => {
-                        Err(String::from("html_root_url attribute without URL"))
-                    }
-                    _ => continue,
-                };
+        if ident.as_ref() != "doc" {
+            continue;
+        }
 
-                match check_result {
-                    Ok(()) => {
-                        // FIXME: re-add line numbers and position in line when `syn` will have
-                        // enough capabilities to do so
-                        println!("{} ... ok", path);
-                        return Ok(());
+        for nested_meta_item in nested_meta_items {
+            let check_result = match *nested_meta_item {
+                syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref name, ref value))
+                    if name == "html_root_url" => {
+                    match *value {
+                        // accept both cooked and raw strings here
+                        syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
+                        // non-string html_root_url is probably an
+                        // error, but we leave this check to compiler
+                        _ => continue,
                     }
-                    Err(err) => {
-                        println!("{} ... {}", path, err);
-                        return Err(format!("html_root_url errors in {}", path));
-                    }
+                }
+                syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref name))
+                    if name == "html_root_url" => {
+                    Err(String::from("html_root_url attribute without URL"))
+                }
+                _ => continue,
+            };
+
+            match check_result {
+                Ok(()) => {
+                    // FIXME: re-add line numbers and position in line
+                    // when `syn` will have enough capabilities to do
+                    // so
+                    println!("{} ... ok", path);
+                    return Ok(());
+                }
+                Err(err) => {
+                    println!("{} ... {}", path, err);
+                    return Err(format!("html_root_url errors in {}", path));
                 }
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -399,8 +399,9 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
     let version = parse_version(pkg_version)
         .map_err(|err| format!("bad package version {:?}: {}", pkg_version, err))?;
 
-    let krate = syn::parse_crate(&code)
-        .map_err(|source| format!("could not parse {} with source:\n{}", path, source))?;
+    let krate =
+        syn::parse_crate(&code)
+            .map_err(|source| format!("could not parse {} with source:\n{}", path, source))?;
 
     println!("Checking doc attributes in {}...", path);
     for attr in krate.attrs {
@@ -412,22 +413,22 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
             } if ident.as_ref() == "doc" => {
                 for nested_meta_item in nested_meta_items {
                     let check_result = match *nested_meta_item {
-                        syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref name, ref value))
-                            if name == "html_root_url" =>
-                        {
-                            match *value {
-                                // accept both cooked and raw strings here
-                                syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
-                                // non-string html_root_url is probably an error, but we leave
-                                // this check to compiler
-                                _ => continue,
+                        syn::NestedMetaItem::MetaItem(syn::MetaItem::NameValue(ref name,
+                                                                               ref value)) if name == "html_root_url" => {
+                            {
+                                match *value {
+                                    // accept both cooked and raw strings here
+                                    syn::Lit::Str(ref s, _) => url_matches(s, pkg_name, &version),
+                                    // non-string html_root_url is probably an error, but we leave
+                                    // this check to compiler
+                                    _ => continue,
+                                }
                             }
-                        },
+                        }
                         syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref name))
-                            if name == "html_root_url" =>
-                        {
+                            if name == "html_root_url" => {
                             Err(String::from("html_root_url attribute without URL"))
-                        },
+                        }
                         _ => continue,
                     };
 
@@ -437,14 +438,14 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
                             // enough capabilities to do so
                             println!("{} ... ok", path);
                             return Ok(());
-                        },
+                        }
                         Err(err) => {
                             println!("{} ... {}", path, err);
                             return Err(format!("html_root_url errors in {}", path));
-                        },
+                        }
                     }
                 }
-            },
+            }
             _ => continue,
         }
     }


### PR DESCRIPTION
This simply refactors the code a little to reduce the amount of nesting in the parsing. We can probably reduce this further — perhaps with clever use of `and_then` on a `Result` type. I'll leave this for another time :-)