### PR TITLE
travis: bump minimum Rust version to 1.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.15.0
+  - 1.17.0 # ~4 releases behind latest stable
   - stable
   - beta
   - nightly

--- a/README.md
+++ b/README.md
@@ -113,6 +113,11 @@ your_crate = "0.1.2"
 
 This is a changelog describing the most important changes per release.
 
+### Unreleased
+
+Bumped oldest supported Rust version from 1.15 to 1.17 in order to
+avoid pinning our dependencies at old versions.
+
 ### Version 0.4.0 — November 1st, 2017
 
 This release replaces the dependency on the abandoned `syntex_syntax`


### PR DESCRIPTION
Rust 1.17 is roughly four releases older than the current stable
release. Using this version will allow us to avoid pinning our
dependencies to old versions and will allow version-sync to be
packaged for Fedora (see #30).