### PR TITLE
travis: run 'cargo update'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ rust:
 
 cache: cargo
 
+before_script:
+  - cargo update
+
 matrix:
   allow_failures:
     - rust: nightly


### PR DESCRIPTION
This should help avoid situations like reported in #39 where the
minimum rustc requirements change without us noticing.