### PR TITLE
Update to syn 0.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.17.0 # ~4 releases behind latest stable
+  - 1.21.0 # ~4 releases behind latest stable
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ codecov = { repository = "mgeisler/version-sync" }
 [dependencies]
 pulldown-cmark = { version = "0.1", default-features = false }
 semver-parser = "0.7"
-syn = { version = "0.13", features = ["full"] }
+syn = { version = "0.14", features = ["full"] }
 toml = "0.4"
 url = "1.5.1"
 itertools = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,7 +414,7 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
             _ => continue,
         };
 
-        if ident.as_ref() != "doc" {
+        if ident != "doc" {
             continue;
         }
 


### PR DESCRIPTION
syn wasn't able to parse my lib.rs, likely because it didn't support
statement attributes. This should fix that, and it even makes a piece of
code slightly simpler.