### PR TITLE
rustfmt: standarize formatting

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,5 +1,0 @@
-array_layout = "Visual"
-fn_args_layout = "Visual"
-fn_call_style = "Visual"
-generics_indent = "Visual"
-struct_lit_width = 40


### PR DESCRIPTION
This brings the formatting back in line with the defaults for rustfmt,
plus it reformats the file using a recent nightly rustfmt which means
the imports are now sorted.