### PR TITLE
Accept Git dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,27 @@ your_crate = "0.1.2"
 
 This is a changelog describing the most important changes per release.
 
+### Unreleased
+
+Dependencies were updated and `version-sync` now requires Rust version
+1.21 or later.
+
+Git dependencies are now always accepted, which means that blocks like
+
+~~~markdown
+```toml
+[dependencies]
+your_crate = { git = "..." }
+```
+~~~
+
+will work without you having to add `no_sync`.
+
+Issues closed:
+
+* [#42][issue-42]: Handle Git dependencies
+
+
 ### Version 0.5.0 — November 19th, 2017
 
 Dependencies were updated and `version-sync` now requires Rust version
@@ -180,3 +201,4 @@ Contributions will be accepted under the same license.
 [codecov]: https://codecov.io/gh/mgeisler/version-sync
 [mit]: LICENSE
 [issue-19]: https://github.com/mgeisler/version-sync/issues/19
+[issue-42]: https://github.com/mgeisler/version-sync/issues/42

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -674,10 +674,7 @@ mod tests {
             let block = "[dependencies]\n\
                          foobar = '1.5'";
             let request = extract_version_request("foobar", block);
-            assert_eq!(
-                request.unwrap().predicates,
-                parse_request("1.5").unwrap().predicates
-            );
+            assert_eq!(request.unwrap(), parse_request("1.5").unwrap());
         }
 
         #[test]
@@ -685,10 +682,7 @@ mod tests {
             let block = "[dependencies]\n\
                          foobar = { version = '1.5', default-features = false }";
             let request = extract_version_request("foobar", block);
-            assert_eq!(
-                request.unwrap().predicates,
-                parse_request("1.5").unwrap().predicates
-            );
+            assert_eq!(request.unwrap(), parse_request("1.5").unwrap());
         }
 
         #[test]
@@ -698,10 +692,7 @@ mod tests {
             let block = "[dependencies]\n\
                          foobar = { git = 'https://example.net/foobar.git' }";
             let request = extract_version_request("foobar", block);
-            assert_eq!(
-                request.unwrap().predicates,
-                parse_request("*").unwrap().predicates
-            );
+            assert_eq!(request.unwrap(), parse_request("*").unwrap());
         }
 
         #[test]
@@ -709,10 +700,7 @@ mod tests {
             let block = "[dev-dependencies]\n\
                          foobar = '1.5'";
             let request = extract_version_request("foobar", block);
-            assert_eq!(
-                request.unwrap().predicates,
-                parse_request("1.5").unwrap().predicates
-            );
+            assert_eq!(request.unwrap(), parse_request("1.5").unwrap());
         }
 
         #[test]


### PR DESCRIPTION
Before, a `foo = { git = '...' }` dependency would result in an error saying "no dependency on foo", which is clearly incorrect. We now simply ignore such Git dependencies since there is nothing for the crate author to update in such blocks.