### PR TITLE
appveyor: run 'cargo update'

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ matrix:
     - TOOLCHAIN: nightly
 
 install:
-  - ps: Start-FileDownload 'https://win.rustup.rs/' -FileName rustup-init.exe
+  - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-toolchain %TOOLCHAIN%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,9 @@ install:
   - rustup-init.exe -y --default-toolchain %TOOLCHAIN%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 
+before_build:
+  - cargo update
+
 build_script:
   - cargo build --verbose
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ matrix:
     - TOOLCHAIN: nightly
 
 install:
-  - ps: Start-FileDownload 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-gnu/rustup-init.exe'
+  - ps: Start-FileDownload 'https://win.rustup.rs/' -FileName rustup-init.exe
   - rustup-init.exe -y --default-toolchain %TOOLCHAIN%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 


### PR DESCRIPTION
This should help avoid situations like reported in #39 where the
minimum rustc requirements change without us noticing.