### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ appveyor = { repository = "mgeisler/version-sync" }
 codecov = { repository = "mgeisler/version-sync" }
 
 [dependencies]
-pulldown-cmark = { version = "0.1", default-features = false }
+pulldown-cmark = { version = "0.2", default-features = false }
 semver-parser = "0.9"
 syn = { version = "0.15", features = ["full"] }
 toml = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,6 @@ semver-parser = "0.9"
 syn = { version = "0.15", features = ["full"] }
 toml = "0.4"
 url = "1.5.1"
-itertools = "0.7"
+itertools = "0.8"
 regex = "1.1"
 lazy_static = "1.2"


### PR DESCRIPTION
This updates all dependencies to their latest version -- which is no longer a problem now that we require Rust 1.27.2.