### PR TITLE
Update to Rust 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: rust
 
 rust:
-  - 1.27.2 # ~4 releases behind latest stable
+  - 1.31.0 # Rust 2018
   - stable
   - beta
   - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ appveyor = { repository = "mgeisler/version-sync" }
 codecov = { repository = "mgeisler/version-sync" }
 
 [dependencies]
-pulldown-cmark = { version = "0.2", default-features = false }
+pulldown-cmark = { version = "0.4", default-features = false }
 semver-parser = "0.9"
 syn = { version = "0.15", features = ["full"] }
 toml = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ codecov = { repository = "mgeisler/version-sync" }
 pulldown-cmark = { version = "0.4", default-features = false }
 semver-parser = "0.9"
 syn = { version = "0.15", features = ["full"] }
-toml = "0.4"
+toml = "0.5"
 url = "1.5.1"
 itertools = "0.8"
 regex = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ keywords = ["version"]
 categories = ["development-tools", "rust-patterns"]
 license = "MIT"
 exclude = [".dir-locals.el"]
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "mgeisler/version-sync" }

--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ your_crate = "0.1.2"
 
 This is a changelog describing the most important changes per release.
 
+### Unreleased ###
+
+We now use Rust 2018, which means we reqire Rust version 1.31.0 or
+later.
+
 ### Version 0.7.0 — January 14th, 2019
 
 Special characters are now correctly escaped in the `{name}` and

--- a/src/contains_regex.rs
+++ b/src/contains_regex.rs
@@ -1,6 +1,6 @@
 use regex::{escape, Regex};
 
-use helpers::{read_file, Result};
+use crate::helpers::{read_file, Result};
 
 /// Check that `path` contain the regular expression given by
 /// `template`.

--- a/src/html_root_url.rs
+++ b/src/html_root_url.rs
@@ -4,7 +4,7 @@ use semver_parser::version::Version;
 use syn;
 use url::Url;
 
-use helpers::{indent, read_file, version_matches_request, Result};
+use crate::helpers::{indent, read_file, version_matches_request, Result};
 
 fn url_matches(value: &str, pkg_name: &str, version: &Version) -> Result<()> {
     let url = Url::parse(value).map_err(|err| format!("parse error: {}", err))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,22 +52,14 @@
 #![doc(html_root_url = "https://docs.rs/version-sync/0.7.0")]
 #![deny(missing_docs)]
 
-extern crate itertools;
-extern crate pulldown_cmark;
-extern crate regex;
-extern crate semver_parser;
-extern crate syn;
-extern crate toml;
-extern crate url;
-
 mod contains_regex;
 mod helpers;
 mod html_root_url;
 mod markdown_deps;
 
-pub use contains_regex::check_contains_regex;
-pub use html_root_url::check_html_root_url;
-pub use markdown_deps::check_markdown_deps;
+pub use crate::contains_regex::check_contains_regex;
+pub use crate::html_root_url::check_html_root_url;
+pub use crate::markdown_deps::check_markdown_deps;
 
 /// Assert that dependencies on the current package are up to date.
 ///

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -4,7 +4,7 @@ use semver_parser::range::VersionReq;
 use semver_parser::version::parse as parse_version;
 use toml::Value;
 
-use helpers::{indent, read_file, version_matches_request, Result};
+use crate::helpers::{indent, read_file, version_matches_request, Result};
 
 /// A fenced code block.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -20,7 +20,7 @@ impl<'a> CodeBlock<'a> {
     /// works for fenced code blocks. The `start` index must be the
     /// first line of data in the code block, `end` must be right
     /// after the final newline of a fenced code block.
-    fn new(text: &'a str, start: usize, end: usize) -> CodeBlock {
+    fn new(text: &'a str, start: usize, end: usize) -> CodeBlock<'_> {
         // A code block with no closing fence is reported as being
         // closed at the end of the file. In that case, we cannot be
         // sure to find a final newline.
@@ -79,7 +79,7 @@ fn is_toml_block(lang: &str) -> bool {
 }
 
 /// Find all TOML code blocks in a Markdown text.
-fn find_toml_blocks(text: &str) -> Vec<CodeBlock> {
+fn find_toml_blocks(text: &str) -> Vec<CodeBlock<'_>> {
     let mut parser = Parser::new(text);
     let mut code_blocks = Vec::new();
     let mut start = 0;

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -15,27 +15,6 @@ struct CodeBlock<'a> {
     first_line: usize,
 }
 
-impl<'a> CodeBlock<'a> {
-    /// Contruct a new code block from text[start..end]. This only
-    /// works for fenced code blocks. The `start` index must be the
-    /// first line of data in the code block, `end` must be right
-    /// after the final newline of a fenced code block.
-    fn new(text: &'a str, start: usize, end: usize) -> CodeBlock<'_> {
-        // A code block with no closing fence is reported as being
-        // closed at the end of the file. In that case, we cannot be
-        // sure to find a final newline.
-        let last_nl = match text[..end - 1].rfind('\n') {
-            Some(i) => i + 1,
-            None => start,
-        };
-        let first_line = 1 + text[..start].lines().count();
-        CodeBlock {
-            content: &text[start..last_nl],
-            first_line: first_line,
-        }
-    }
-}
-
 /// Extract a dependency on the given package from a TOML code block.
 fn extract_version_request(pkg_name: &str, block: &str) -> Result<VersionReq> {
     match block.parse::<Value>() {
@@ -80,23 +59,20 @@ fn is_toml_block(lang: &str) -> bool {
 
 /// Find all TOML code blocks in a Markdown text.
 fn find_toml_blocks(text: &str) -> Vec<CodeBlock<'_>> {
-    let mut parser = Parser::new(text);
+    let parser = Parser::new(text);
     let mut code_blocks = Vec::new();
-    let mut start = 0;
-    // A normal for-loop doesn't work since that would borrow the
-    // parser mutably for the duration of the loop body, preventing us
-    // from calling get_offset later.
-    while let Some(event) = parser.next() {
+    for (event, range) in parser.into_offset_iter() {
         match event {
-            Event::Start(Tag::CodeBlock(_)) => {
-                start = parser.get_offset();
-            }
-            Event::End(Tag::CodeBlock(lang)) => {
-                // Only fenced code blocks have language information.
-                if is_toml_block(&lang) {
-                    let end = parser.get_offset();
-                    code_blocks.push(CodeBlock::new(text, start, end));
-                }
+            Event::Start(Tag::CodeBlock(ref lang)) if is_toml_block(lang) => {
+                let line_count = text[..range.start].lines().count();
+                let code_block = &text[range];
+                let start = 1 + code_block.find('\n').unwrap_or(0);
+                let end = 1 + code_block.rfind('\n').unwrap_or(0);
+
+                code_blocks.push(CodeBlock {
+                    content: &code_block[start..end],
+                    first_line: 2 + line_count,
+                });
             }
             _ => {}
         }
@@ -172,17 +148,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn empty_toml_block() {
+    fn empty_markdown_file() {
         assert_eq!(find_toml_blocks(""), vec![]);
     }
 
     #[test]
-    fn indented_toml_block() {
+    fn indented_code_block() {
         assert_eq!(find_toml_blocks("    code block\n"), vec![]);
     }
 
     #[test]
-    fn single_line_toml_block() {
+    fn empty_toml_block() {
         assert_eq!(
             find_toml_blocks("```toml\n```"),
             vec![CodeBlock {
@@ -204,20 +180,18 @@ mod tests {
     }
 
     #[test]
-    fn code_block_new() {
+    fn nonempty_toml_block() {
         let text = "Preceding text.\n\
-                    ```\n\
+                    ```toml\n\
                     foo\n\
                     ```\n\
                     Trailing text";
-        let start = text.find("```\n").unwrap() + 4;
-        let end = text.rfind("```\n").unwrap() + 4;
         assert_eq!(
-            CodeBlock::new(text, start, end),
-            CodeBlock {
+            find_toml_blocks(&text),
+            vec![CodeBlock {
                 content: "foo\n",
                 first_line: 3
-            }
+            }]
         );
     }
 


### PR DESCRIPTION
This pull request updates the code to the Rust 2018 edition, which means that we now require Rust 1.31.0 or later.