### PR TITLE
doc: update example to use macros directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,14 @@ version-sync = "0.7"
 
 Then create a `tests/version-numbers.rs` file with:
 ```rust
-#[macro_use]
-extern crate version_sync;
-
 #[test]
 fn test_readme_deps() {
-    assert_markdown_deps_updated!("README.md");
+    version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
 fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
 }
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,19 +20,16 @@
 //! `tests/version-numbers.rs` file with:
 //!
 //! ```rust
-//! #[macro_use]
-//! extern crate version_sync;
-//!
 //! #[test]
 //! # fn fake_hidden_test_case_1() {}
 //! fn test_readme_deps() {
-//!     assert_markdown_deps_updated!("README.md");
+//!     version_sync::assert_markdown_deps_updated!("README.md");
 //! }
 //!
 //! #[test]
 //! # fn fake_hidden_test_case_2() {}
 //! fn test_html_root_url() {
-//!     assert_html_root_url_updated!("src/lib.rs");
+//!     version_sync::assert_html_root_url_updated!("src/lib.rs");
 //! }
 //!
 //! # fn main() {
@@ -76,14 +73,11 @@ pub use crate::markdown_deps::check_markdown_deps;
 /// The typical way to use this macro is from an integration test:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate version_sync;
-///
 /// #[test]
 /// # fn fake_hidden_test_case() {}
 /// # // The above function ensures test_readme_deps is compiled.
 /// fn test_readme_deps() {
-///     assert_markdown_deps_updated!("README.md");
+///     version_sync::assert_markdown_deps_updated!("README.md");
 /// }
 ///
 /// # fn main() {
@@ -130,14 +124,11 @@ macro_rules! assert_markdown_deps_updated {
 /// The typical way to use this macro is from an integration test:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate version_sync;
-///
 /// #[test]
 /// # fn fake_hidden_test_case() {}
 /// # // The above function ensures test_html_root_url is compiled.
 /// fn test_html_root_url() {
-///     assert_html_root_url_updated!("src/lib.rs");
+///     version_sync::assert_html_root_url_updated!("src/lib.rs");
 /// }
 ///
 /// # fn main() {
@@ -184,15 +175,12 @@ macro_rules! assert_html_root_url_updated {
 /// The typical way to use this macro is from an integration test:
 ///
 /// ```rust
-/// #[macro_use]
-/// extern crate version_sync;
-///
 /// #[test]
 /// # fn fake_hidden_test_case() {}
 /// # // The above function ensures test_readme_mentions_version is
 /// # // compiled.
 /// fn test_readme_mentions_version() {
-///     assert_contains_regex!("README.md", "^### Version {version}");
+///     version_sync::assert_contains_regex!("README.md", "^### Version {version}");
 /// }
 ///
 /// # fn main() {

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,17 +1,17 @@
-#[macro_use]
-extern crate version_sync;
-
 #[test]
 fn test_readme_deps() {
-    assert_markdown_deps_updated!("README.md");
+    version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
 fn test_readme_changelog() {
-    assert_contains_regex!("README.md", r"^### Version {version} — .* \d\d?.., 20\d\d$");
+    version_sync::assert_contains_regex!(
+        "README.md",
+        r"^### Version {version} — .* \d\d?.., 20\d\d$"
+    );
 }
 
 #[test]
 fn test_html_root_url() {
-    assert_html_root_url_updated!("src/lib.rs");
+    version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
With Rust 2018, we no longer need the macro_use attribute. Instead we
can simply use the macros like other items in the crate.

This simplifies the tests a bit.