### PR TITLE
check_html_root_url: report accurate line numbers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ codecov = { repository = "mgeisler/version-sync" }
 pulldown-cmark = { version = "0.4", default-features = false }
 semver-parser = "0.9"
 syn = { version = "0.15", features = ["full"] }
+# Enable the span-locations feature in proc-macro2, the exact version
+# is determined by the syn crate.
+proc-macro2 = { version = "*", features = ["span-locations"] }
 toml = "0.5"
 url = "1.5.1"
 itertools = "0.8"

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ This is a changelog describing the most important changes per release.
 ### Unreleased ###
 
 We now use Rust 2018, which means we reqire Rust version 1.31.0 or
-later.
+later. The `assert_html_root_url_updated!` macro will again report
+accurate line numbers based on span information from the `syn` crate.
 
 ### Version 0.7.0 — January 14th, 2019
 


### PR DESCRIPTION
Before we used a heuristic by grepping the file for "html_root_url",
now we use the span information from the syn crate.