### PR TITLE
tests: escape the version number

### DIFF
--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -13,7 +13,7 @@ fn test_readme_changelog() {
 
 #[test]
 fn test_minimum_rustc_version() {
-    let version = "1.31.0";
+    let version = r"1\.31\.0";
     version_sync::assert_contains_regex!(".travis.yml", &format!(r"^  - {}", version));
     version_sync::assert_contains_regex!("README.md", &format!("badge/rustc-{}", version));
 }


### PR DESCRIPTION
This prevents (unlikely) false positives.