### PR TITLE
cargo: fix version of proc-macro2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ codecov = { repository = "mgeisler/version-sync" }
 pulldown-cmark = { version = "0.4", default-features = false }
 semver-parser = "0.9"
 syn = { version = "0.15", features = ["full"] }
-# Enable the span-locations feature in proc-macro2, the exact version
-# is determined by the syn crate.
-proc-macro2 = { version = "*", features = ["span-locations"] }
+proc-macro2 = { version = "0.4", features = ["span-locations"] }
 toml = "0.5"
 url = "1.5.1"
 itertools = "0.8"


### PR DESCRIPTION
It turns out that you cannot publish a package on crates.io if it has
a wildcard dependency:

    error: api errors: wildcard (`*`) dependency constraints are not
    allowed on crates.io.