### PR TITLE
Drop Rust 2018 compatibility

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,11 +1,6 @@
 environment:
   matrix:
   - TOOLCHAIN: stable
-  - TOOLCHAIN: nightly
-
-matrix:
-  allow_failures:
-    - TOOLCHAIN: nightly
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: rust
 
 rust:
-  - 1.31.0 # Rust 2018
   - stable
   - nightly
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,6 @@ appveyor = { repository = "mgeisler/version-sync" }
 codecov = { repository = "mgeisler/version-sync" }
 
 [dependencies]
-# This crate is compatible with Rust 2018, i.e., Rustc version 1.31.0.
-# Version requirements of dependencies can be bumped as long as the
-# dependencies compile with that compiler version. Some versions
-# requirements below an upper limit to indicate when the dependency
-# stops compiling with a Rust 2018 compatible compiler.
 pulldown-cmark = { version = "0.4, <0.5", default-features = false }
 semver-parser = "0.9"
 syn = { version = "1.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,11 @@ appveyor = { repository = "mgeisler/version-sync" }
 codecov = { repository = "mgeisler/version-sync" }
 
 [dependencies]
-pulldown-cmark = { version = "0.4, <0.5", default-features = false }
+pulldown-cmark = { version = "0.7", default-features = false }
 semver-parser = "0.9"
 syn = { version = "1.0", features = ["full"] }
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 toml = "0.5"
-url = "1.0, <2.0"
-itertools = "0.8"
+url = "2.0"
+itertools = "0.9"
 regex = "1.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![](https://img.shields.io/crates/v/version-sync.svg)][crates-io]
 [![](https://docs.rs/version-sync/badge.svg)][api-docs]
-[![](https://img.shields.io/badge/rustc-1.31.0-4d76ae.svg)][rust-2018]
 [![](https://travis-ci.org/mgeisler/version-sync.svg?branch=master)][travis-ci]
 [![](https://ci.appveyor.com/api/projects/status/github/mgeisler/version-sync?branch=master&svg=true)][appveyor]
 [![](https://codecov.io/gh/mgeisler/version-sync/branch/master/graph/badge.svg)][codecov]
@@ -108,6 +107,22 @@ your_crate = "0.1.2"
 ## Release History
 
 This is a changelog describing the most important changes per release.
+
+### Unreleased
+
+Drop support for Rust 1.31.0 since our dependencies keep releasing new
+patch versions that push up the minimum required Rust version. These
+updates mean that `version-sync` 0.8.1 no longer compiles with Rust
+1.31.0 because `cargo sync` will pull in too new versions of the
+direct and transitive dependencies. This happens even if there are no
+changes in `version-sync`.
+
+The constant build failures in our CI makes it infeasible to keep
+`version-sync` compatible with any particular version of Rust. We will
+therefore track the latest stable version of Rust from now on.
+
+At the time of writing, the code compiles with Rust 1.36, but this
+will likely become outdated soon.
 
 ### Version 0.8.1 — April 3rd, 2019
 

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -1,4 +1,4 @@
-use pulldown_cmark::{Event, Parser, Tag};
+use pulldown_cmark::{CodeBlockKind::Fenced, Event, Parser, Tag};
 use semver_parser::range::parse as parse_request;
 use semver_parser::range::VersionReq;
 use semver_parser::version::parse as parse_version;
@@ -63,7 +63,7 @@ fn find_toml_blocks(text: &str) -> Vec<CodeBlock<'_>> {
     let mut code_blocks = Vec::new();
     for (event, range) in parser.into_offset_iter() {
         match event {
-            Event::Start(Tag::CodeBlock(ref lang)) if is_toml_block(lang) => {
+            Event::Start(Tag::CodeBlock(Fenced(ref lang))) if is_toml_block(lang) => {
                 let line_count = text[..range.start].lines().count();
                 let code_block = &text[range];
                 let start = 1 + code_block.find('\n').unwrap_or(0);

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -63,7 +63,7 @@ fn find_toml_blocks(text: &str) -> Vec<CodeBlock<'_>> {
     let mut code_blocks = Vec::new();
     for (event, range) in parser.into_offset_iter() {
         match event {
-            Event::Start(Tag::CodeBlock(Fenced(ref lang))) if is_toml_block(lang) => {
+            Event::Start(Tag::CodeBlock(Fenced(lang))) if is_toml_block(&lang) => {
                 let line_count = text[..range.start].lines().count();
                 let code_block = &text[range];
                 let start = 1 + code_block.find('\n').unwrap_or(0);

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -12,13 +12,6 @@ fn test_readme_changelog() {
 }
 
 #[test]
-fn test_minimum_rustc_version() {
-    let version = r"1\.31\.0";
-    version_sync::assert_contains_regex!(".travis.yml", &format!(r"^  - {}", version));
-    version_sync::assert_contains_regex!("README.md", &format!("badge/rustc-{}", version));
-}
-
-#[test]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");
 }


### PR DESCRIPTION
I've been trying to keep the crate compatible with Rust 2018, which
corresponds to Rust version 1.31.0. However, this has proven
impossible because of how our dependencies keep releasing new patch
versions that push up the minimum required Rust version.

Because of this, the current code no longer compiles with Rust 1.31.0
because `cargo sync` will pull in too new versions of the direct and
transitive dependencies. This happens even if there are no changes in
`version-sync`.

The failure to compile shows up as spurious and unexpected build
failures in our CI, which in turn makes it hard to trust CI.

I'm concluding that it's infeasible to keep `version-sync` compatible
with any particular version of Rust. While not perfect, we'll track
the latest stable version of Rust from now on. This is not perfect
since even stable Rust sometimes decides to turn warnings into hard
errors: https://github.com/rust-lang/rust/pull/64221/