### PR TITLE
appveyor: use minimal rustup profile

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -4,7 +4,7 @@ environment:
 
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-toolchain %TOOLCHAIN%
+  - rustup-init.exe -y --profile minimal --default-toolchain %TOOLCHAIN%
   - set PATH=%PATH%;%USERPROFILE%\.cargo\bin
 
 before_build:


### PR DESCRIPTION
This avoids downloading things like documentation, which in turn
should speed up builds.