### PR TITLE
Pull in fewer dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,5 +27,4 @@ syn = { version = "1.0", features = ["full"] }
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 toml = "0.5"
 url = "2.0"
-itertools = "0.9"
 regex = { version = "1.1", default-features = false, features = ["std", "unicode"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ syn = { version = "1.0", features = ["full"] }
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 toml = "0.5"
 url = "2.0"
-regex = { version = "1.1", default-features = false, features = ["std", "unicode"] }
+regex = { version = "1.3", default-features = false, features = ["std", "unicode"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,4 @@ proc-macro2 = { version = "1.0", features = ["span-locations"] }
 toml = "0.5"
 url = "2.0"
 itertools = "0.9"
-regex = "1.1"
+regex = { version = "1.1", default-features = false, features = ["std", "unicode"] }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,13 +1,34 @@
+use std::fmt::Display;
 use std::fs::File;
 use std::io::{self, Read};
 use std::result;
 
-use itertools::join;
 use semver_parser::range::{Op, VersionReq};
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
 pub type Result<T> = result::Result<T, String>;
+
+fn join<T>(iter: T, sep: &str) -> String
+where
+    T: IntoIterator,
+    T::Item: Display,
+{
+    let mut buf = String::new();
+    let mut iter = iter.into_iter();
+    if let Some(item) = iter.next() {
+        let item = item.to_string();
+        buf.push_str(&item);
+    } else {
+        return buf;
+    }
+    for item in iter {
+        buf.push_str(sep);
+        let item = item.to_string();
+        buf.push_str(&item);
+    }
+    buf
+}
 
 /// Return all data from `path`.
 pub fn read_file(path: &str) -> io::Result<String> {


### PR DESCRIPTION
This PR removes these crates from the dependency tree of `version-sync`:

- `itertools`
- `either`
- `aho-corasick`
- `thread_local`
- `lazy_static`

To remove `itertools` and `either`, I reimplemented a free function for joining an iterator with a separator. The implementation is short and fairly straightforward, which I hope means the maintenance burden is acceptable. This also allows removing an entire crate with only 15 lines of code.

To remove the remaining dependencies, I deactivated all `regex` features except `std` and `unicode`.

Thank you for the great tests! They made it easy to see what was safe to remove.