### PR TITLE
Normalize "\r\n" to "\n" to ensure ^ and $ match line boundaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ proc-macro2 = { version = "1.0", features = ["span-locations"] }
 toml = "0.5"
 url = "2.0"
 regex = { version = "1.3", default-features = false, features = ["std", "unicode"] }
+
+[dev-dependencies]
+tempfile = "3.1"

--- a/src/contains_regex.rs
+++ b/src/contains_regex.rs
@@ -118,4 +118,22 @@ mod tests {
         )
     }
 
+    #[test]
+    fn line_boundaries() {
+        // The regex crate doesn't treat \r\n as a line boundary
+        // (https://github.com/rust-lang/regex/issues/244), so
+        // version-sync makes sure to normalize \r\n to \n when
+        // reading files.
+        use std::io::Write;
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+
+        println!("Path: {}", file.path().to_str().unwrap());
+
+        file.write_all(b"first line\r\nsecond line\r\nthird line\r\n")
+            .unwrap();
+        assert_eq!(
+            check_contains_regex(file.path().to_str().unwrap(), "^second line$", "", ""),
+            Ok(())
+        )
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -30,12 +30,14 @@ where
     buf
 }
 
-/// Return all data from `path`.
+/// Return all data from `path`. Line boundaries are normalized from
+/// "\r\n" to "\n" to make sure "^" and "$" will match them. See
+/// https://github.com/rust-lang/regex/issues/244 for details.
 pub fn read_file(path: &str) -> io::Result<String> {
     let mut file = File::open(path)?;
     let mut buf = String::new();
     file.read_to_string(&mut buf)?;
-    Ok(buf)
+    Ok(buf.replace("\r\n", "\n"))
 }
 
 /// Indent every line in text by four spaces.


### PR DESCRIPTION
The regex crate only considers "\n" a line boundary, so ^ and $ don't
match "\r\n". This can be a problem if code is checked out on Windows
and Git helpfully rewrites your "\n" to "\r\n". I ran into this
problem when testing GitHub Actions on the textwrap repository.

See https://github.com/rust-lang/regex/issues/244.