### PR TITLE
Standardize changelog dates to ISO-8601

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ your_crate = "0.1.2"
 
 This is a changelog describing the most important changes per release.
 
-### Version 0.9.1 — July 7th, 2020
+### Version 0.9.1 — 2020-07-07
 
 * [#91](https://github.com/mgeisler/version-sync/pull/91): Pull in
   fewer dependencies. This optimizes the build time by 1-2 seconds.
@@ -115,7 +115,7 @@ This is a changelog describing the most important changes per release.
 * [#92](https://github.com/mgeisler/version-sync/pull/92): Normalize
   `\r\n` to `\n` to ensure `^` and `$` always match line boundaries.
 
-### Version 0.9.0 — March 30th, 2020
+### Version 0.9.0 — 2020-03-30
 
 Drop support for Rust 1.31.0 since our dependencies keep releasing new
 patch versions that push up the minimum required Rust version. These
@@ -137,18 +137,18 @@ Issues closed:
   blockquotes
 * [#84][issue-84]: Release update to crates.io with syn 1.0
 
-### Version 0.8.1 — April 3rd, 2019
+### Version 0.8.1 — 2019-04-03
 
 Dependencies were relaxed to make it easier to upgrade `version-sync`.
 
-### Version 0.8.0 — March 28th, 2019
+### Version 0.8.0 — 2019-03-28
 
 We now use [Rust 2018][rust-2018], which means we require Rust version
 1.31.0 or later. The `assert_html_root_url_updated!` macro will again
 report accurate line numbers based on span information from the `syn`
 crate.
 
-### Version 0.7.0 — January 14th, 2019
+### Version 0.7.0 — 2019-01-14
 
 Special characters are now correctly escaped in the `{name}` and
 `{version}` placeholders in `assert_contains_regex!`.
@@ -156,7 +156,7 @@ Special characters are now correctly escaped in the `{name}` and
 Dependencies were updated and `version-sync` now requires Rust version
 1.27.2 or later.
 
-### Version 0.6.0 — November 22nd, 2018
+### Version 0.6.0 — 2018-11-22
 
 You can use `assert_contains_regex!` to grep files for the current
 version number. The search is done with a regular expression where
@@ -180,7 +180,7 @@ Issues closed:
 * [#42][issue-42]: Handle Git dependencies
 
 
-### Version 0.5.0 — November 19th, 2017
+### Version 0.5.0 — 2017-11-19
 
 Dependencies were updated and `version-sync` now requires Rust version
 1.21 or later.
@@ -189,7 +189,7 @@ Error messages from `assert_html_root_url_updated!` now again include
 line numbers (based on a heuristic until the `syn` crate can provide
 the information).
 
-### Version 0.4.0 — November 1st, 2017
+### Version 0.4.0 — 2017-11-01
 
 This release replaces the dependency on the abandoned `syntex_syntax`
 with with a dependency on the much lighter `syn` crate. This improves
@@ -197,7 +197,7 @@ compilation speed. Unfortunately, the `syn` crate does not provide
 information about line numbers, so error messages are are no longer as
 good. We might be able to work around that in a later version.
 
-### Version 0.3.1 — September 26th, 2017
+### Version 0.3.1 — 2017-09-26
 
 This release fixes a small problem with the handling of pre-release
 identifiers.
@@ -206,7 +206,7 @@ Issues closed:
 
 * [#19][issue-19]: Pre-release identifiers were ignored.
 
-### Version 0.3.0 — September 23rd, 2017
+### Version 0.3.0 — 2017-09-23
 
 When checking dependencies in READMEs, TOML blocks can now be excluded
 from the check by adding `no_sync` to the language line:
@@ -221,13 +221,13 @@ your_crate = "0.1"
 This TOML block will not be checked. This is similar to `no_run` for
 Rust code blocks.
 
-### Version 0.2.0 — September 20th, 2017
+### Version 0.2.0 — 2017-09-20
 
 Added `assert_html_root_url_updated!` which will check that the
 `html_root_url` attribute points to the correct version of the crate
 documentation on docs.rs.
 
-### Version 0.1.3 — September 18th, 2017
+### Version 0.1.3 — 2017-09-18
 
 First public release with support for finding outdated version numbers
 in `dependencies` and `dev-dependencies`.

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -7,7 +7,7 @@ fn test_readme_deps() {
 fn test_readme_changelog() {
     version_sync::assert_contains_regex!(
         "README.md",
-        r"^### Version {version} — .* \d\d?.., 20\d\d$"
+        r"^### Version {version} — 20\d\d-\d\d-\d\d$"
     );
 }
 


### PR DESCRIPTION
These dates are more homogeneous and they match what will be generated by the automatic release script in `.github/workflows/prepare-release.yml`.