### PR TITLE
Remove Emacs config file from repository

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,3 +1,0 @@
-((nil
-  (bug-reference-bug-regexp . "#\\(?2:[0-9]+\\)")
-  (bug-reference-url-format . "https://github.com/mgeisler/version-sync/issues/%s")))

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ readme = "README.md"
 keywords = ["version"]
 categories = ["development-tools", "rust-patterns"]
 license = "MIT"
-exclude = [".dir-locals.el"]
 edition = "2018"
 
 [badges]


### PR DESCRIPTION
It turns out I’m not using this as much as I expected — and I can always configure it in other ways if needed.