### PR TITLE
Remove unused [badges] section from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,6 @@ categories = ["development-tools", "rust-patterns"]
 license = "MIT"
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "mgeisler/version-sync" }
-appveyor = { repository = "mgeisler/version-sync" }
-codecov = { repository = "mgeisler/version-sync" }
-
 [dependencies]
 pulldown-cmark = { version = "0.8", default-features = false }
 semver-parser = "0.9"


### PR DESCRIPTION
The badges are no longer shown on crates.io and I don’t think they were ever shown on lib.rs. According to the documentation we should instead rely on the badges in the README.

  https://doc.rust-lang.org/cargo/reference/manifest.html#the-badges-section