### PR TITLE
Feature-gate tests to reduce dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,17 +38,17 @@ jobs:
 
         # Use if statement to invert exit code: this should fail
       - name: Check failure to build with no features
-        run: if cargo check; then false; else true; fi
+        run: if cargo check --no-default-features; then false; else true; fi
         shell: bash
 
-      - name: Build and test with markdown feature
-        run: cargo test --features markdown
+      - name: Build and test with markdown_deps_updated feature
+        run: cargo test --no-default-features --features markdown_deps_updated
 
-      - name: Build and test with html_root_url feature
-        run: cargo test --features html_root_url
+      - name: Build and test with html_root_url_updated feature
+        run: cargo test --no-default-features --features html_root_url_updated
 
-      - name: Build and test with regex feature
-        run: cargo test --features regex_version
+      - name: Build and test with contains_regex feature
+        run: cargo test --no-default-features --features contains_regex
 
       - name: Build and test with all features
         run: cargo test --all-features

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         # Use if statement to invert exit code: this should fail
       - name: Check failure to build with no features
         run: if cargo check; then false; else true; fi
+        shell: bash
 
       - name: Build and test with markdown feature
         run: cargo test --features markdown

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,8 +32,25 @@ jobs:
       - name: Install ${{ matrix.rust }} Rust
         run: rustup default ${{ matrix.rust }}
 
-      - name: Build and test
-        run: cargo test
+        # Verify that features work by themselves
+        # Features should not interfere with each other
+        # Should only need to check 0, 1, and (all) 3 features enabled
+
+        # Use if statement to invert exit code: this should fail
+      - name: Check failure to build with no features
+        run: if cargo check; then false; else true; fi
+
+      - name: Build and test with markdown feature
+        run: cargo test --features markdown
+
+      - name: Build and test with html_root_url feature
+        run: cargo test --features html_root_url
+
+      - name: Build and test with regex feature
+        run: cargo test --features regex_version
+
+      - name: Build and test with all features
+        run: cargo test --all-features
 
   build-documentation:
     name: Build documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 [features]
 markdown_deps_updated = ["pulldown-cmark", "semver-parser", "toml"]
 html_root_url = ["url", "semver-parser", "syn", "proc-macro2"]
-regex_version = ["regex"]
+contains_regex = ["regex"]
 
 [dependencies]
 pulldown-cmark = { version = "0.8", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ license = "MIT"
 edition = "2018"
 
 [features]
-markdown = ["pulldown-cmark", "semver-parser", "toml"]
+markdown_deps_updated = ["pulldown-cmark", "semver-parser", "toml"]
 html_root_url = ["url", "semver-parser", "syn", "proc-macro2"]
 regex_version = ["regex"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 
 [features]
 markdown_deps_updated = ["pulldown-cmark", "semver-parser", "toml"]
-html_root_url = ["url", "semver-parser", "syn", "proc-macro2"]
+html_root_url_updated = ["url", "semver-parser", "syn", "proc-macro2"]
 contains_regex = ["regex"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT"
 edition = "2018"
 
 [features]
+default = ["markdown_deps_updated", "html_root_url_updated", "contains_regex"]
 markdown_deps_updated = ["pulldown-cmark", "semver-parser", "toml"]
 html_root_url_updated = ["url", "semver-parser", "syn", "proc-macro2"]
 contains_regex = ["regex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,19 @@ categories = ["development-tools", "rust-patterns"]
 license = "MIT"
 edition = "2018"
 
+[features]
+markdown = ["pulldown-cmark", "semver-parser", "toml"]
+html_root_url = ["url", "semver-parser", "syn", "proc-macro2"]
+regex_version = ["regex"]
+
 [dependencies]
-pulldown-cmark = { version = "0.8", default-features = false }
-semver-parser = "0.9"
-syn = { version = "1.0", features = ["full"] }
-proc-macro2 = { version = "1.0", features = ["span-locations"] }
-toml = "0.5"
-url = "2.0"
-regex = { version = "1.3", default-features = false, features = ["std", "unicode"] }
+pulldown-cmark = { version = "0.8", default-features = false, optional = true }
+semver-parser = { version = "0.9", optional = true }
+syn = { version = "1.0", default-features = false, features = ["parsing", "printing", "full"], optional = true }
+proc-macro2 = { version = "1.0", default-features = false, features = ["span-locations"], optional = true }
+toml = { version = "0.5", optional = true }
+url = { version = "2.0", optional = true }
+regex = { version = "1.3", default-features = false, features = ["std", "unicode"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/src/contains_regex.rs
+++ b/src/contains_regex.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "regex_version")]
+#![cfg(feature = "contains_regex")]
 use regex::{escape, Regex};
 
 use crate::helpers::{read_file, Result};

--- a/src/contains_regex.rs
+++ b/src/contains_regex.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "regex_version")]
 use regex::{escape, Regex};
 
 use crate::helpers::{read_file, Result};

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,26 +1,26 @@
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 use std::fmt::Display;
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
 use std::fs::File;
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
 use std::io::{self, Read};
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
 use std::result;
 
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 use semver_parser::range::{Op, VersionReq};
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
 pub type Result<T> = result::Result<T, String>;
 
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 fn join<T>(iter: T, sep: &str) -> String
 where
     T: IntoIterator,
@@ -45,7 +45,7 @@ where
 /// Return all data from `path`. Line boundaries are normalized from
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
 pub fn read_file(path: &str) -> io::Result<String> {
     let mut file = File::open(path)?;
@@ -55,13 +55,13 @@ pub fn read_file(path: &str) -> io::Result<String> {
 }
 
 /// Indent every line in text by four spaces.
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 pub fn indent(text: &str) -> String {
     join(text.lines().map(|line| String::from("    ") + line), "\n")
 }
 
 /// Verify that the version range request matches the given version.
-#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 pub fn version_matches_request(version: &Version, request: &VersionReq) -> Result<()> {
     if request.predicates.len() != 1 {
         // Can only handle simple dependencies
@@ -109,15 +109,15 @@ pub fn version_matches_request(version: &Version, request: &VersionReq) -> Resul
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+    #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
     use semver_parser::range::parse as parse_request;
-    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+    #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
     use semver_parser::version::parse as parse_version;
 
-    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+    #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
     use super::*;
 
-    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
+    #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
     mod test_version_matches_request {
         use super::*;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,14 +1,22 @@
+#[cfg(any(feature = "html_root_url", feature = "markdown"))]
 use std::fmt::Display;
+#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
 use std::fs::File;
+#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
 use std::io::{self, Read};
+#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
 use std::result;
 
+#[cfg(any(feature = "html_root_url", feature = "markdown"))]
 use semver_parser::range::{Op, VersionReq};
+#[cfg(any(feature = "html_root_url", feature = "markdown"))]
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
+#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
 pub type Result<T> = result::Result<T, String>;
 
+#[cfg(any(feature = "html_root_url", feature = "markdown"))]
 fn join<T>(iter: T, sep: &str) -> String
 where
     T: IntoIterator,
@@ -33,6 +41,7 @@ where
 /// Return all data from `path`. Line boundaries are normalized from
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
+#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
 pub fn read_file(path: &str) -> io::Result<String> {
     let mut file = File::open(path)?;
     let mut buf = String::new();
@@ -41,11 +50,13 @@ pub fn read_file(path: &str) -> io::Result<String> {
 }
 
 /// Indent every line in text by four spaces.
+#[cfg(any(feature = "html_root_url", feature = "markdown"))]
 pub fn indent(text: &str) -> String {
     join(text.lines().map(|line| String::from("    ") + line), "\n")
 }
 
 /// Verify that the version range request matches the given version.
+#[cfg(any(feature = "html_root_url", feature = "markdown"))]
 pub fn version_matches_request(version: &Version, request: &VersionReq) -> Result<()> {
     if request.predicates.len() != 1 {
         // Can only handle simple dependencies
@@ -93,11 +104,15 @@ pub fn version_matches_request(version: &Version, request: &VersionReq) -> Resul
 
 #[cfg(test)]
 mod tests {
+    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
     use semver_parser::range::parse as parse_request;
+    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
     use semver_parser::version::parse as parse_version;
 
+    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
     use super::*;
 
+    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
     mod test_version_matches_request {
         use super::*;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -31,8 +31,6 @@ where
 /// Return all data from `path`. Line boundaries are normalized from
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
-    feature = "contains_regex"))]
 pub fn read_file(path: &str) -> std::io::Result<String> {
     use std::io::Read;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,8 +4,6 @@ use semver_parser::range::VersionReq;
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
-    feature = "contains_regex"))]
 pub type Result<T> = std::result::Result<T, String>;
 
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,13 +1,13 @@
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 use std::fmt::Display;
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
-    feature = "regex_version"))]
+    feature = "contains_regex"))]
 use std::fs::File;
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
-    feature = "regex_version"))]
+    feature = "contains_regex"))]
 use std::io::{self, Read};
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
-    feature = "regex_version"))]
+    feature = "contains_regex"))]
 use std::result;
 
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
@@ -17,7 +17,7 @@ use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
-    feature = "regex_version"))]
+    feature = "contains_regex"))]
 pub type Result<T> = result::Result<T, String>;
 
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
@@ -46,7 +46,7 @@ where
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
 #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
-    feature = "regex_version"))]
+    feature = "contains_regex"))]
 pub fn read_file(path: &str) -> io::Result<String> {
     let mut file = File::open(path)?;
     let mut buf = String::new();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,10 +1,13 @@
 #[cfg(any(feature = "html_root_url", feature = "markdown"))]
 use std::fmt::Display;
-#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown",
+    feature = "regex_version"))]
 use std::fs::File;
-#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown",
+    feature = "regex_version"))]
 use std::io::{self, Read};
-#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown",
+    feature = "regex_version"))]
 use std::result;
 
 #[cfg(any(feature = "html_root_url", feature = "markdown"))]
@@ -13,7 +16,8 @@ use semver_parser::range::{Op, VersionReq};
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
-#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown",
+    feature = "regex_version"))]
 pub type Result<T> = result::Result<T, String>;
 
 #[cfg(any(feature = "html_root_url", feature = "markdown"))]
@@ -41,7 +45,8 @@ where
 /// Return all data from `path`. Line boundaries are normalized from
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
-#[cfg(any(feature = "html_root_url", feature = "markdown", feature = "regex_version"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown",
+    feature = "regex_version"))]
 pub fn read_file(path: &str) -> io::Result<String> {
     let mut file = File::open(path)?;
     let mut buf = String::new();

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,26 +1,26 @@
-#[cfg(any(feature = "html_root_url", feature = "markdown"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 use std::fmt::Display;
-#[cfg(any(feature = "html_root_url", feature = "markdown",
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
     feature = "regex_version"))]
 use std::fs::File;
-#[cfg(any(feature = "html_root_url", feature = "markdown",
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
     feature = "regex_version"))]
 use std::io::{self, Read};
-#[cfg(any(feature = "html_root_url", feature = "markdown",
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
     feature = "regex_version"))]
 use std::result;
 
-#[cfg(any(feature = "html_root_url", feature = "markdown"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 use semver_parser::range::{Op, VersionReq};
-#[cfg(any(feature = "html_root_url", feature = "markdown"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
-#[cfg(any(feature = "html_root_url", feature = "markdown",
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
     feature = "regex_version"))]
 pub type Result<T> = result::Result<T, String>;
 
-#[cfg(any(feature = "html_root_url", feature = "markdown"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 fn join<T>(iter: T, sep: &str) -> String
 where
     T: IntoIterator,
@@ -45,7 +45,7 @@ where
 /// Return all data from `path`. Line boundaries are normalized from
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
-#[cfg(any(feature = "html_root_url", feature = "markdown",
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated",
     feature = "regex_version"))]
 pub fn read_file(path: &str) -> io::Result<String> {
     let mut file = File::open(path)?;
@@ -55,13 +55,13 @@ pub fn read_file(path: &str) -> io::Result<String> {
 }
 
 /// Indent every line in text by four spaces.
-#[cfg(any(feature = "html_root_url", feature = "markdown"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 pub fn indent(text: &str) -> String {
     join(text.lines().map(|line| String::from("    ") + line), "\n")
 }
 
 /// Verify that the version range request matches the given version.
-#[cfg(any(feature = "html_root_url", feature = "markdown"))]
+#[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
 pub fn version_matches_request(version: &Version, request: &VersionReq) -> Result<()> {
     if request.predicates.len() != 1 {
         // Can only handle simple dependencies
@@ -109,15 +109,15 @@ pub fn version_matches_request(version: &Version, request: &VersionReq) -> Resul
 
 #[cfg(test)]
 mod tests {
-    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
+    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
     use semver_parser::range::parse as parse_request;
-    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
+    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
     use semver_parser::version::parse as parse_version;
 
-    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
+    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
     use super::*;
 
-    #[cfg(any(feature = "html_root_url", feature = "markdown"))]
+    #[cfg(any(feature = "html_root_url", feature = "markdown_deps_updated"))]
     mod test_version_matches_request {
         use super::*;
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,30 +1,18 @@
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
-use std::fmt::Display;
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
-    feature = "contains_regex"))]
-use std::fs::File;
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
-    feature = "contains_regex"))]
-use std::io::{self, Read};
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
-    feature = "contains_regex"))]
-use std::result;
-
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
-use semver_parser::range::{Op, VersionReq};
+use semver_parser::range::VersionReq;
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 use semver_parser::version::Version;
 
 /// The common result type, our errors will be simple strings.
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
-pub type Result<T> = result::Result<T, String>;
+pub type Result<T> = std::result::Result<T, String>;
 
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 fn join<T>(iter: T, sep: &str) -> String
 where
     T: IntoIterator,
-    T::Item: Display,
+    T::Item: std::fmt::Display,
 {
     let mut buf = String::new();
     let mut iter = iter.into_iter();
@@ -47,8 +35,10 @@ where
 /// https://github.com/rust-lang/regex/issues/244 for details.
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated",
     feature = "contains_regex"))]
-pub fn read_file(path: &str) -> io::Result<String> {
-    let mut file = File::open(path)?;
+pub fn read_file(path: &str) -> std::io::Result<String> {
+    use std::io::Read;
+
+    let mut file = std::fs::File::open(path)?;
     let mut buf = String::new();
     file.read_to_string(&mut buf)?;
     Ok(buf.replace("\r\n", "\n"))
@@ -63,6 +53,7 @@ pub fn indent(text: &str) -> String {
 /// Verify that the version range request matches the given version.
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 pub fn version_matches_request(version: &Version, request: &VersionReq) -> Result<()> {
+    use semver_parser::range::Op;
     if request.predicates.len() != 1 {
         // Can only handle simple dependencies
         return Ok(());

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,9 +1,4 @@
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
-use semver_parser::range::VersionReq;
-#[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
-use semver_parser::version::Version;
-
-// Some imports are inside the function bodies to scope them in a cfg block.
+// Imports are inside the function bodies to scope them in a cfg block.
 
 /// The common result type, our errors will be simple strings.
 pub type Result<T> = std::result::Result<T, String>;
@@ -50,7 +45,8 @@ pub fn indent(text: &str) -> String {
 
 /// Verify that the version range request matches the given version.
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
-pub fn version_matches_request(version: &Version, request: &VersionReq) -> Result<()> {
+pub fn version_matches_request(version: &semver_parser::version::Version,
+        request: &semver_parser::range::VersionReq) -> Result<()> {
     use semver_parser::range::Op;
     if request.predicates.len() != 1 {
         // Can only handle simple dependencies

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -3,6 +3,8 @@ use semver_parser::range::VersionReq;
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
 use semver_parser::version::Version;
 
+// Some imports are inside the function bodies to scope them in a cfg block.
+
 /// The common result type, our errors will be simple strings.
 pub type Result<T> = std::result::Result<T, String>;
 

--- a/src/html_root_url.rs
+++ b/src/html_root_url.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "html_root_url")]
+#![cfg(feature = "html_root_url_updated")]
 use semver_parser::range::parse as parse_request;
 use semver_parser::version::parse as parse_version;
 use semver_parser::version::Version;

--- a/src/html_root_url.rs
+++ b/src/html_root_url.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "html_root_url")]
 use semver_parser::range::parse as parse_request;
 use semver_parser::version::parse as parse_version;
 use semver_parser::version::Version;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 //! version numbers need updating:
 //!
 //! * TOML examples in the `README.md` files that show how to add a
-//!   dependency on your crate, gated behind the "markdown" feature.
+//!   dependency on your crate, gated behind the
+//!   "markdown_deps_updated" feature.
 //!   See [`assert_markdown_deps_updated`].
 //!
 //! * A `Changelog.md` file that should at least mention the current
@@ -27,7 +28,7 @@
 //! ```rust
 //! #[test]
 //! # fn fake_hidden_test_case_1() {}
-//! # #[cfg(feature = "markdown")]
+//! # #[cfg(feature = "markdown_deps_updated")]
 //! fn test_readme_deps() {
 //!     version_sync::assert_markdown_deps_updated!("README.md");
 //! }
@@ -40,7 +41,7 @@
 //! }
 //!
 //! # fn main() {
-//! #     #[cfg(feature = "markdown")]
+//! #     #[cfg(feature = "markdown_deps_updated")]
 //! #     test_readme_deps();
 //! #     #[cfg(feature = "html_root_url")]
 //! #     test_html_root_url();
@@ -65,18 +66,18 @@ mod markdown_deps;
 
 // Ensure that at least one feature is enabled
 #[cfg(not(any(feature = "regex_version", feature = "html_root_url",
-    feature = "markdown")))]
+    feature = "markdown_deps_updated")))]
 std::compile_error!("Please select at least one feature.");
 
 #[cfg(feature = "regex_version")]
 pub use crate::contains_regex::check_contains_regex;
 #[cfg(feature = "html_root_url")]
 pub use crate::html_root_url::check_html_root_url;
-#[cfg(feature = "markdown")]
+#[cfg(feature = "markdown_deps_updated")]
 pub use crate::markdown_deps::check_markdown_deps;
 
 /// Assert that dependencies on the current package are up to date.
-/// Requires the "markdown" feature.
+/// Requires the "markdown_deps_updated" feature.
 ///
 /// The macro will call [`check_markdown_deps`] on the file name given
 /// in order to check that the TOML examples found all depend on a
@@ -113,7 +114,7 @@ pub use crate::markdown_deps::check_markdown_deps;
 ///
 /// [`check_markdown_deps`]: fn.check_markdown_deps.html
 #[macro_export]
-#[cfg(feature = "markdown")]
+#[cfg(feature = "markdown_deps_updated")]
 macro_rules! assert_markdown_deps_updated {
     ($path:expr) => {
         let pkg_name = env!("CARGO_PKG_NAME");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,18 +22,22 @@
 //! ```rust
 //! #[test]
 //! # fn fake_hidden_test_case_1() {}
+//! # #[cfg(feature = "markdown")]
 //! fn test_readme_deps() {
 //!     version_sync::assert_markdown_deps_updated!("README.md");
 //! }
 //!
 //! #[test]
 //! # fn fake_hidden_test_case_2() {}
+//! # #[cfg(feature = "html_root_url")]
 //! fn test_html_root_url() {
 //!     version_sync::assert_html_root_url_updated!("src/lib.rs");
 //! }
 //!
 //! # fn main() {
+//! #     #[cfg(feature = "markdown")]
 //! #     test_readme_deps();
+//! #     #[cfg(feature = "html_root_url")]
 //! #     test_html_root_url();
 //! # }
 //! ```
@@ -54,8 +58,15 @@ mod helpers;
 mod html_root_url;
 mod markdown_deps;
 
+// Hacky workaround to ensure that at least one feature is enabled
+#[cfg(not(any(feature = "regex_version", feature = "html_root_url", feature = "markdown")))]
+const AT_LEAST_ONE_FEATURE_ENABLED: u32 = "bad";
+
+#[cfg(feature = "regex_version")]
 pub use crate::contains_regex::check_contains_regex;
+#[cfg(feature = "html_root_url")]
 pub use crate::html_root_url::check_html_root_url;
+#[cfg(feature = "markdown")]
 pub use crate::markdown_deps::check_markdown_deps;
 
 /// Assert that dependencies on the current package are up to date.
@@ -95,6 +106,7 @@ pub use crate::markdown_deps::check_markdown_deps;
 ///
 /// [`check_markdown_deps`]: fn.check_markdown_deps.html
 #[macro_export]
+#[cfg(feature = "markdown")]
 macro_rules! assert_markdown_deps_updated {
     ($path:expr) => {
         let pkg_name = env!("CARGO_PKG_NAME");
@@ -147,6 +159,7 @@ macro_rules! assert_markdown_deps_updated {
 /// [api-guidelines]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root
 /// [`check_html_root_url`]: fn.check_html_root_url.html
 #[macro_export]
+#[cfg(feature = "html_root_url")]
 macro_rules! assert_html_root_url_updated {
     ($path:expr) => {
         let pkg_name = env!("CARGO_PKG_NAME");
@@ -210,6 +223,7 @@ macro_rules! assert_html_root_url_updated {
 ///
 /// [`check_contains_regex`]: fn.check_contains_regex.html
 #[macro_export]
+#[cfg(feature = "regex_version")]
 macro_rules! assert_contains_regex {
     ($path:expr, $format:expr) => {
         let pkg_name = env!("CARGO_PKG_NAME");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,13 +7,18 @@
 //! version numbers need updating:
 //!
 //! * TOML examples in the `README.md` files that show how to add a
-//!   dependency on your crate. See [`assert_markdown_deps_updated`].
+//!   dependency on your crate, gated behind the "markdown" feature.
+//!   See [`assert_markdown_deps_updated`].
 //!
 //! * A `Changelog.md` file that should at least mention the current
-//!   version. See [`assert_contains_regex`].
+//!   version, gated behind the "regex_version" feature.
+//!   See [`assert_contains_regex`].
 //!
 //! * The [`html_root_url`] attribute that tells other crates where to
-//!   find your documentation. See [`assert_html_root_url_updated`].
+//!   find your documentation, gated behind the "html_root_url" feature.
+//!   See [`assert_html_root_url_updated`].
+//!
+//! At least one of the three features must be enabled.
 //!
 //! A typical configuration will use an integration test to verify
 //! that all version numbers are in sync. Create a
@@ -70,6 +75,7 @@ pub use crate::html_root_url::check_html_root_url;
 pub use crate::markdown_deps::check_markdown_deps;
 
 /// Assert that dependencies on the current package are up to date.
+/// Requires the "markdown" feature.
 ///
 /// The macro will call [`check_markdown_deps`] on the file name given
 /// in order to check that the TOML examples found all depend on a
@@ -118,6 +124,7 @@ macro_rules! assert_markdown_deps_updated {
 }
 
 /// Assert that the `html_root_url` attribute is up to date.
+/// Requires the "html_root_url" feature.
 ///
 /// Library code is [expected to set `html_root_url`][api-guidelines]
 /// to point to docs.rs so that rustdoc can generate correct links
@@ -171,6 +178,7 @@ macro_rules! assert_html_root_url_updated {
 }
 
 /// Assert that versions numbers are up to date via a regex.
+/// Requires the "regex_version" feature.
 ///
 /// This macro allows you verify that the current version number is
 /// mentioned in a particular file, such as a changelog file. You do

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,7 @@
 //!
 //! #[test]
 //! # fn fake_hidden_test_case_2() {}
-//! # #[cfg(feature = "html_root_url")]
+//! # #[cfg(feature = "html_root_url_updated")]
 //! fn test_html_root_url() {
 //!     version_sync::assert_html_root_url_updated!("src/lib.rs");
 //! }
@@ -43,7 +43,7 @@
 //! # fn main() {
 //! #     #[cfg(feature = "markdown_deps_updated")]
 //! #     test_readme_deps();
-//! #     #[cfg(feature = "html_root_url")]
+//! #     #[cfg(feature = "html_root_url_updated")]
 //! #     test_html_root_url();
 //! # }
 //! ```
@@ -65,13 +65,13 @@ mod html_root_url;
 mod markdown_deps;
 
 // Ensure that at least one feature is enabled
-#[cfg(not(any(feature = "contains_regex", feature = "html_root_url",
+#[cfg(not(any(feature = "contains_regex", feature = "html_root_url_updated",
     feature = "markdown_deps_updated")))]
 std::compile_error!("Please select at least one feature.");
 
 #[cfg(feature = "contains_regex")]
 pub use crate::contains_regex::check_contains_regex;
-#[cfg(feature = "html_root_url")]
+#[cfg(feature = "html_root_url_updated")]
 pub use crate::html_root_url::check_html_root_url;
 #[cfg(feature = "markdown_deps_updated")]
 pub use crate::markdown_deps::check_markdown_deps;
@@ -126,7 +126,7 @@ macro_rules! assert_markdown_deps_updated {
 }
 
 /// Assert that the `html_root_url` attribute is up to date.
-/// Requires the "html_root_url" feature.
+/// Requires the "html_root_url_updated" feature.
 ///
 /// Library code is [expected to set `html_root_url`][api-guidelines]
 /// to point to docs.rs so that rustdoc can generate correct links
@@ -168,7 +168,7 @@ macro_rules! assert_markdown_deps_updated {
 /// [api-guidelines]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root
 /// [`check_html_root_url`]: fn.check_html_root_url.html
 #[macro_export]
-#[cfg(feature = "html_root_url")]
+#[cfg(feature = "html_root_url_updated")]
 macro_rules! assert_html_root_url_updated {
     ($path:expr) => {
         let pkg_name = env!("CARGO_PKG_NAME");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,11 @@ mod html_root_url;
 mod markdown_deps;
 
 // Ensure that at least one feature is enabled
-#[cfg(not(any(feature = "regex_version", feature = "html_root_url",
+#[cfg(not(any(feature = "contains_regex", feature = "html_root_url",
     feature = "markdown_deps_updated")))]
 std::compile_error!("Please select at least one feature.");
 
-#[cfg(feature = "regex_version")]
+#[cfg(feature = "contains_regex")]
 pub use crate::contains_regex::check_contains_regex;
 #[cfg(feature = "html_root_url")]
 pub use crate::html_root_url::check_html_root_url;
@@ -180,7 +180,7 @@ macro_rules! assert_html_root_url_updated {
 }
 
 /// Assert that versions numbers are up to date via a regex.
-/// Requires the "regex_version" feature.
+/// Requires the "contains_regex" feature.
 ///
 /// This macro allows you verify that the current version number is
 /// mentioned in a particular file, such as a changelog file. You do
@@ -233,7 +233,7 @@ macro_rules! assert_html_root_url_updated {
 ///
 /// [`check_contains_regex`]: fn.check_contains_regex.html
 #[macro_export]
-#[cfg(feature = "regex_version")]
+#[cfg(feature = "contains_regex")]
 macro_rules! assert_contains_regex {
     ($path:expr, $format:expr) => {
         let pkg_name = env!("CARGO_PKG_NAME");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,10 +63,10 @@ mod helpers;
 mod html_root_url;
 mod markdown_deps;
 
-// Hacky workaround to ensure that at least one feature is enabled
+// Ensure that at least one feature is enabled
 #[cfg(not(any(feature = "regex_version", feature = "html_root_url",
     feature = "markdown")))]
-const AT_LEAST_ONE_FEATURE_ENABLED: u32 = "bad";
+std::compile_error!("Please select at least one feature.");
 
 #[cfg(feature = "regex_version")]
 pub use crate::contains_regex::check_contains_regex;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,8 @@ mod html_root_url;
 mod markdown_deps;
 
 // Hacky workaround to ensure that at least one feature is enabled
-#[cfg(not(any(feature = "regex_version", feature = "html_root_url", feature = "markdown")))]
+#[cfg(not(any(feature = "regex_version", feature = "html_root_url",
+    feature = "markdown")))]
 const AT_LEAST_ONE_FEATURE_ENABLED: u32 = "bad";
 
 #[cfg(feature = "regex_version")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,15 @@
 //! `version-sync` provides macros for keeping version numbers in sync
 //! with your crate version.
 //!
+//! # Library Overview
+//!
 //! When making a release of a Rust project, you typically need to
 //! adjust some version numbers in your code and documentation. This
 //! crate gives you macros that covers some typical cases where
 //! version numbers need updating:
 //!
 //! * TOML examples in the `README.md` files that show how to add a
-//!   dependency on your crate, gated behind the
-//!   "markdown_deps_updated" feature.
-//!   See [`assert_markdown_deps_updated`].
+//!   dependency on your crate. See [`assert_markdown_deps_updated`].
 //!
 //! * A `Changelog.md` file that should at least mention the current
 //!   version, gated behind the "regex_version" feature.
@@ -19,7 +19,7 @@
 //!   find your documentation, gated behind the "html_root_url" feature.
 //!   See [`assert_html_root_url_updated`].
 //!
-//! At least one of the three features must be enabled.
+//! The macros are gated behind individual features, as detailed below.
 //!
 //! A typical configuration will use an integration test to verify
 //! that all version numbers are in sync. Create a
@@ -51,6 +51,16 @@
 //! When you run `cargo test`, your version numbers will be
 //! automatically checked.
 //!
+//! # Cargo Features
+//!
+//! Each of the macros above are gated behind a feature:
+//!
+//! * `markdown_deps_updated` enables [`assert_markdown_deps_updated`].
+//! * `html_root_url_updated` enables [`assert_html_root_url_updated`].
+//! * `contains_regex` enables [`assert_contains_regex`].
+//!
+//! All of these features are enabled by default.
+//!
 //! [`html_root_url`]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root
 //! [`assert_markdown_deps_updated`]: macro.assert_markdown_deps_updated.html
 //! [`assert_html_root_url_updated`]: macro.assert_html_root_url_updated.html
@@ -77,7 +87,6 @@ pub use crate::html_root_url::check_html_root_url;
 pub use crate::markdown_deps::check_markdown_deps;
 
 /// Assert that dependencies on the current package are up to date.
-/// Requires the "markdown_deps_updated" feature.
 ///
 /// The macro will call [`check_markdown_deps`] on the file name given
 /// in order to check that the TOML examples found all depend on a
@@ -86,6 +95,8 @@ pub use crate::markdown_deps::check_markdown_deps;
 /// version is taken from `$CARGO_PKG_VERSION`. These environment
 /// variables are automatically set by Cargo when compiling your
 /// crate.
+///
+/// This macro is enabled by the `markdown_deps_updated` feature.
 ///
 /// # Usage
 ///
@@ -126,7 +137,6 @@ macro_rules! assert_markdown_deps_updated {
 }
 
 /// Assert that the `html_root_url` attribute is up to date.
-/// Requires the "html_root_url_updated" feature.
 ///
 /// Library code is [expected to set `html_root_url`][api-guidelines]
 /// to point to docs.rs so that rustdoc can generate correct links
@@ -139,6 +149,8 @@ macro_rules! assert_markdown_deps_updated {
 /// environment variable and the version is taken from
 /// `$CARGO_PKG_VERSION`. These environment variables are
 /// automatically set by Cargo when compiling your crate.
+///
+/// This macro is enabled by the `html_root_url_updated` feature.
 ///
 /// # Usage
 ///
@@ -180,7 +192,6 @@ macro_rules! assert_html_root_url_updated {
 }
 
 /// Assert that versions numbers are up to date via a regex.
-/// Requires the "contains_regex" feature.
 ///
 /// This macro allows you verify that the current version number is
 /// mentioned in a particular file, such as a changelog file. You do
@@ -192,6 +203,8 @@ macro_rules! assert_html_root_url_updated {
 /// taken from the `$CARGO_PKG_NAME` and `$CARGO_PKG_VERSION`
 /// environment variables. These environment variables are
 /// automatically set by Cargo when compiling your crate.
+///
+/// This macro is enabled by the `contains_regex` feature.
 ///
 /// # Usage
 ///

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "markdown")]
+#![cfg(feature = "markdown_deps_updated")]
 use pulldown_cmark::{CodeBlockKind::Fenced, Event, Parser, Tag};
 use semver_parser::range::parse as parse_request;
 use semver_parser::range::VersionReq;

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -1,3 +1,4 @@
+#![cfg(feature = "markdown")]
 use pulldown_cmark::{CodeBlockKind::Fenced, Event, Parser, Tag};
 use semver_parser::range::parse as parse_request;
 use semver_parser::range::VersionReq;

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,5 +1,5 @@
 #[test]
-#[cfg(feature = "markdown")]
+#[cfg(feature = "markdown_deps_updated")]
 fn test_readme_deps() {
     version_sync::assert_markdown_deps_updated!("README.md");
 }

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -1,9 +1,11 @@
 #[test]
+#[cfg(feature = "markdown")]
 fn test_readme_deps() {
     version_sync::assert_markdown_deps_updated!("README.md");
 }
 
 #[test]
+#[cfg(feature = "regex_version")]
 fn test_readme_changelog() {
     version_sync::assert_contains_regex!(
         "README.md",
@@ -12,6 +14,7 @@ fn test_readme_changelog() {
 }
 
 #[test]
+#[cfg(feature = "html_root_url")]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");
 }

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -14,7 +14,7 @@ fn test_readme_changelog() {
 }
 
 #[test]
-#[cfg(feature = "html_root_url")]
+#[cfg(feature = "html_root_url_updated")]
 fn test_html_root_url() {
     version_sync::assert_html_root_url_updated!("src/lib.rs");
 }

--- a/tests/version-numbers.rs
+++ b/tests/version-numbers.rs
@@ -5,7 +5,7 @@ fn test_readme_deps() {
 }
 
 #[test]
-#[cfg(feature = "regex_version")]
+#[cfg(feature = "contains_regex")]
 fn test_readme_changelog() {
     version_sync::assert_contains_regex!(
         "README.md",


### PR DESCRIPTION
This PR adds three features, one for each macro, and allows a user who only needs one macro to avoid dependencies that are only needed for the other macros.

Feedback requested:
- Bikeshedding the feature names
- Deciding which features to turn on by default