### PR TITLE
Forbid the use of unsafe code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@
 //! [`assert_contains_regex`]: macro.assert_contains_regex.html
 
 #![doc(html_root_url = "https://docs.rs/version-sync/0.9.2")]
+#![forbid(unsafe_code)]
 #![deny(missing_docs)]
 
 mod contains_regex;


### PR DESCRIPTION
This is to avoid us accidentally introducing unsafe code and to make the crate show up in green with `cargo geiger`, see

  https://github.com/rust-secure-code/cargo-geiger