### PR TITLE
Add simple `check_contains_version` function

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,9 @@ jobs:
 
         # Verify that features work by themselves
         # Features should not interfere with each other
-        # Should only need to check 0, 1, and (all) 3 features enabled
 
-        # Use if statement to invert exit code: this should fail
-      - name: Check failure to build with no features
-        run: if cargo check --no-default-features; then false; else true; fi
-        shell: bash
+      - name: Build and test with no default feature
+        run: cargo test --no-default-features
 
       - name: Build and test with markdown_deps_updated feature
         run: cargo test --no-default-features --features markdown_deps_updated

--- a/src/contains_substring.rs
+++ b/src/contains_substring.rs
@@ -1,0 +1,67 @@
+use crate::helpers::{read_file, Result};
+
+/// Check that `path` contain the substring given by `template`.
+///
+/// The placeholders `{name}` and `{version}` will be replaced with
+/// `pkg_name` and `pkg_version`, if they are present in `template`.
+/// It is okay if `template` do not contain these placeholders.
+///
+/// See [`check_contains_regex`](crate::check_contains_regex) if you
+/// want to match with a regular expression instead.
+///
+/// # Errors
+///
+/// If the template cannot be found, an `Err` is returned with a
+/// succinct error message. Status information has then already been
+/// printed on `stdout`.
+pub fn check_contains_substring(
+    path: &str,
+    template: &str,
+    pkg_name: &str,
+    pkg_version: &str,
+) -> Result<()> {
+    // Expand the optional {name} and {version} placeholders in the
+    // template. This is almost like
+    //
+    //   format!(template, name = pkg_name, version = pkg_version)
+    //
+    // but allows the user to leave out unnecessary placeholders.
+    let pattern = template
+        .replace("{name}", &pkg_name)
+        .replace("{version}", &pkg_version);
+
+    let text = read_file(path).map_err(|err| format!("could not read {}: {}", path, err))?;
+
+    println!("Searching for \"{}\" in {}...", template, path);
+    match text.find(&pattern) {
+        Some(idx) => {
+            let line_no = text[..idx].lines().count();
+            println!("{} (line {}) ... ok", path, line_no + 1);
+            Ok(())
+        }
+        None => Err(format!("could not find \"{}\" in {}", pattern, path)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pattern_not_found() {
+        assert_eq!(
+            check_contains_substring("README.md", "should not be found", "foobar", "1.2.3"),
+            Err(String::from(
+                "could not find \"should not be found\" in README.md"
+            ))
+        )
+    }
+
+    #[test]
+    fn pattern_found() {
+        assert_eq!(
+            check_contains_substring("README.md", "{name}", "version-sync", "1.2.3"),
+            Ok(())
+        )
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,4 +1,5 @@
-// Imports are inside the function bodies to scope them in a cfg block.
+use std::fs::File;
+use std::io::{self, Read};
 
 /// The common result type, our errors will be simple strings.
 pub type Result<T> = std::result::Result<T, String>;
@@ -28,10 +29,8 @@ where
 /// Return all data from `path`. Line boundaries are normalized from
 /// "\r\n" to "\n" to make sure "^" and "$" will match them. See
 /// https://github.com/rust-lang/regex/issues/244 for details.
-pub fn read_file(path: &str) -> std::io::Result<String> {
-    use std::io::Read;
-
-    let mut file = std::fs::File::open(path)?;
+pub fn read_file(path: &str) -> io::Result<String> {
+    let mut file = File::open(path)?;
     let mut buf = String::new();
     file.read_to_string(&mut buf)?;
     Ok(buf.replace("\r\n", "\n"))
@@ -45,8 +44,10 @@ pub fn indent(text: &str) -> String {
 
 /// Verify that the version range request matches the given version.
 #[cfg(any(feature = "html_root_url_updated", feature = "markdown_deps_updated"))]
-pub fn version_matches_request(version: &semver_parser::version::Version,
-        request: &semver_parser::range::VersionReq) -> Result<()> {
+pub fn version_matches_request(
+    version: &semver_parser::version::Version,
+    request: &semver_parser::range::VersionReq,
+) -> Result<()> {
     use semver_parser::range::Op;
     if request.predicates.len() != 1 {
         // Can only handle simple dependencies


### PR DESCRIPTION
This function searches for the a template using a simple substring match. It is always enabled since it doesn’t need anything outside the standard library.