### PR TITLE
Move from deprecated `semver-parser` to `semver`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ edition = "2018"
 
 [features]
 default = ["markdown_deps_updated", "html_root_url_updated", "contains_regex"]
-markdown_deps_updated = ["pulldown-cmark", "semver-parser", "toml"]
-html_root_url_updated = ["url", "semver-parser", "syn", "proc-macro2"]
+markdown_deps_updated = ["pulldown-cmark", "semver", "toml"]
+html_root_url_updated = ["url", "semver", "syn", "proc-macro2"]
 contains_regex = ["regex"]
 
 [dependencies]
 pulldown-cmark = { version = "0.8", default-features = false, optional = true }
-semver-parser = { version = "0.9", optional = true }
+semver = { version = "1.0", optional = true }
 syn = { version = "1.0", default-features = false, features = ["parsing", "printing", "full"], optional = true }
 proc-macro2 = { version = "1.0", default-features = false, features = ["span-locations"], optional = true }
 toml = { version = "0.5", optional = true }


### PR DESCRIPTION
Based on steveklabnik/semver-parser@dc6c1077899d, I gather that we should use `semver` going forward.
