### PR TITLE
Use precise dependency versions in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ html_root_url_updated = ["url", "semver", "syn", "proc-macro2"]
 contains_regex = ["regex", "semver"]
 
 [dependencies]
-pulldown-cmark = { version = "0.8", default-features = false, optional = true }
-semver = { version = "1.0", optional = true }
-syn = { version = "1.0", default-features = false, features = ["parsing", "printing", "full"], optional = true }
-proc-macro2 = { version = "1.0", default-features = false, features = ["span-locations"], optional = true }
-toml = { version = "0.5", optional = true }
-url = { version = "2.0", optional = true }
-regex = { version = "1.3", default-features = false, features = ["std", "unicode"], optional = true }
+pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
+semver = { version = "1.0.5", optional = true }
+syn = { version = "1.0.86", default-features = false, features = ["parsing", "printing", "full"], optional = true }
+proc-macro2 = { version = "1.0.36", default-features = false, features = ["span-locations"], optional = true }
+toml = { version = "0.5.8", optional = true }
+url = { version = "2.2.2", optional = true }
+regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"], optional = true }
 
 [dev-dependencies]
-tempfile = "3.1"
+tempfile = "3.3.0"


### PR DESCRIPTION
Following the advice from [1], this PR updates Cargo.toml to use precise version numbers for all dependencies. The latest versions at the time of writing are used.

Before, running

```
% cargo -Z minimal-versions update
% cargo test
```

failed on nightly because of a transitive dependency. Now it works again.

[1]: https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277