### PR TITLE
Migrate to the Rust 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["version"]
 categories = ["development-tools", "rust-patterns"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 
 [features]
 default = ["markdown_deps_updated", "html_root_url_updated", "contains_regex"]


### PR DESCRIPTION
No changes necessary.