### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,12 @@ contains_regex = ["regex", "semver"]
 
 [dependencies]
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
-semver = { version = "1.0.5", optional = true }
-syn = { version = "1.0.86", default-features = false, features = ["parsing", "printing", "full"], optional = true }
-proc-macro2 = { version = "1.0.36", default-features = false, features = ["span-locations"], optional = true }
-toml = { version = "0.5.8", optional = true }
+semver = { version = "1.0.7", optional = true }
+syn = { version = "1.0.91", default-features = false, features = ["parsing", "printing", "full"], optional = true }
+proc-macro2 = { version = "1.0.37", default-features = false, features = ["span-locations"], optional = true }
+toml = { version = "0.5.9", optional = true }
 url = { version = "2.2.2", optional = true }
-regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"], optional = true }
+regex = { version = "1.5.5", default-features = false, features = ["std", "unicode"], optional = true }
 
 [dev-dependencies]
 tempfile = "3.3.0"


### PR DESCRIPTION
This fixes a build error trying to build after a `cargo update -Z minimal-versions`.