### PR TITLE
Update syn to v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ contains_regex = ["regex", "semver"]
 [dependencies]
 pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
 semver = { version = "1.0.5", optional = true }
-syn = { version = "1.0.86", default-features = false, features = ["parsing", "printing", "full"], optional = true }
+syn = { version = "2.0.15", default-features = false, features = ["parsing", "printing", "full"], optional = true }
 proc-macro2 = { version = "1.0.36", default-features = false, features = ["span-locations"], optional = true }
 toml = { version = "0.5.8", optional = true }
 url = { version = "2.2.2", optional = true }


### PR DESCRIPTION
This is one of a couple of my dependencies still requiring syn v1. So I took the liberty to update it to v2.

The only change necessary was replacing the code using `NestedMeta`, since that type is no longer available in syn. I replaced it with `Attribute::parse_nested_meta`.