### PR TITLE
Apply Clippy again

### DIFF
--- a/src/contains_regex.rs
+++ b/src/contains_regex.rs
@@ -50,8 +50,8 @@ pub fn check_contains_regex(
     builder.multi_line(true);
     let re = builder
         .build()
-        .map_err(|err| format!("could not parse template: {}", err))?;
-    let text = read_file(path).map_err(|err| format!("could not read {}: {}", path, err))?;
+        .map_err(|err| format!("could not parse template: {err}"))?;
+    let text = read_file(path).map_err(|err| format!("could not read {path}: {err}"))?;
 
     println!("Searching for \"{pattern}\" in {path}...");
     match re.find(&text) {
@@ -103,7 +103,7 @@ pub fn check_only_contains_regex(
     pkg_version: &str,
 ) -> Result<()> {
     let version = Version::parse(pkg_version)
-        .map_err(|err| format!("bad package version {:?}: {}", pkg_version, err))?;
+        .map_err(|err| format!("bad package version {pkg_version:?}: {err}"))?;
 
     let pattern = template
         .replace("{name}", &escape(pkg_name))
@@ -111,11 +111,11 @@ pub fn check_only_contains_regex(
     let re = RegexBuilder::new(&pattern)
         .multi_line(true)
         .build()
-        .map_err(|err| format!("could not parse template: {}", err))?;
+        .map_err(|err| format!("could not parse template: {err}"))?;
 
     let semver_re = Regex::new(SEMVER_RE).unwrap();
 
-    let text = read_file(path).map_err(|err| format!("could not read {}: {}", path, err))?;
+    let text = read_file(path).map_err(|err| format!("could not read {path}: {err}"))?;
 
     println!("Searching for \"{template}\" in {path}...");
     let mut errors = 0;
@@ -127,7 +127,7 @@ pub fn check_only_contains_regex(
 
         for semver in semver_re.find_iter(m.as_str()) {
             let semver_request = VersionReq::parse(semver.as_str())
-                .map_err(|err| format!("could not parse version: {}", err))?;
+                .map_err(|err| format!("could not parse version: {err}"))?;
             let result = version_matches_request(&version, &semver_request);
             match result {
                 Err(err) => {

--- a/src/contains_substring.rs
+++ b/src/contains_substring.rs
@@ -30,7 +30,7 @@ pub fn check_contains_substring(
         .replace("{name}", pkg_name)
         .replace("{version}", pkg_version);
 
-    let text = read_file(path).map_err(|err| format!("could not read {}: {}", path, err))?;
+    let text = read_file(path).map_err(|err| format!("could not read {path}: {err}"))?;
 
     println!("Searching for \"{pattern}\" in {path}...");
     match text.find(&pattern) {

--- a/src/html_root_url.rs
+++ b/src/html_root_url.rs
@@ -7,7 +7,7 @@ use url::Url;
 use crate::helpers::{indent, read_file, version_matches_request, Result};
 
 fn url_matches(value: &str, pkg_name: &str, version: &Version) -> Result<()> {
-    let url = Url::parse(value).map_err(|err| format!("parse error: {}", err))?;
+    let url = Url::parse(value).map_err(|err| format!("parse error: {err}"))?;
 
     // We can only reason about docs.rs.
     if url.domain().is_some() && url.domain() != Some("docs.rs") {
@@ -48,7 +48,7 @@ fn url_matches(value: &str, pkg_name: &str, version: &Version) -> Result<()> {
         // [1]: https://rust-lang-nursery.github.io/api-guidelines/documentation.html
         // #crate-sets-html_root_url-attribute-c-html-root
         VersionReq::parse(request)
-            .map_err(|err| format!("could not parse version in URL: {}", err))
+            .map_err(|err| format!("could not parse version in URL: {err}"))
             .and_then(|request| version_matches_request(version, &request))
     }
 }
@@ -66,11 +66,11 @@ fn url_matches(value: &str, pkg_name: &str, version: &Version) -> Result<()> {
 /// succinct error message. Status information has then already been
 /// printed on `stdout`.
 pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Result<()> {
-    let code = read_file(path).map_err(|err| format!("could not read {}: {}", path, err))?;
+    let code = read_file(path).map_err(|err| format!("could not read {path}: {err}"))?;
     let version = Version::parse(pkg_version)
-        .map_err(|err| format!("bad package version {:?}: {}", pkg_version, err))?;
+        .map_err(|err| format!("bad package version {pkg_version:?}: {err}"))?;
     let krate: syn::File = syn::parse_file(&code)
-        .map_err(|_| format!("could not parse {}: please run \"cargo build\"", path))?;
+        .map_err(|_| format!("could not parse {path}: please run \"cargo build\""))?;
 
     println!("Checking doc attributes in {path}...");
     for attr in krate.attrs {
@@ -105,15 +105,15 @@ pub fn check_html_root_url(path: &str, pkg_name: &str, pkg_version: &str) -> Res
                     let source_lines = code.lines().take(last_line).skip(first_line - 1);
                     match check_result {
                         Ok(()) => {
-                            println!("{} (line {}) ... ok", path, first_line);
+                            println!("{path} (line {first_line}) ... ok");
                             return Ok(());
                         }
                         Err(err) => {
-                            println!("{} (line {}) ... {} in", path, first_line, err);
+                            println!("{path} (line {first_line}) ... {err} in");
                             for line in source_lines {
                                 println!("{}", indent(line));
                             }
-                            return Err(meta.error(format!("html_root_url errors in {}", path)));
+                            return Err(meta.error(format!("html_root_url errors in {path}")));
                         }
                     }
                 }

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -34,7 +34,7 @@ fn extract_version_request(pkg_name: &str, block: &str) -> Result<VersionReq> {
                 });
             match version {
                 Some(version) => VersionReq::parse(version)
-                    .map_err(|err| format!("could not parse dependency: {}", err)),
+                    .map_err(|err| format!("could not parse dependency: {err}")),
                 None => Err(format!("no dependency on {pkg_name}")),
             }
         }
@@ -127,9 +127,9 @@ fn find_toml_blocks(text: &str) -> Vec<CodeBlock> {
 /// error message. Status information has then already been printed on
 /// `stdout`.
 pub fn check_markdown_deps(path: &str, pkg_name: &str, pkg_version: &str) -> Result<()> {
-    let text = read_file(path).map_err(|err| format!("could not read {}: {}", path, err))?;
+    let text = read_file(path).map_err(|err| format!("could not read {path}: {err}"))?;
     let version = Version::parse(pkg_version)
-        .map_err(|err| format!("bad package version {:?}: {}", pkg_version, err))?;
+        .map_err(|err| format!("bad package version {pkg_version:?}: {err}"))?;
 
     println!("Checking code blocks in {path}...");
     let mut failed = false;


### PR DESCRIPTION
Due to https://github.com/rust-lang/rust-clippy/issues/11470, some format strings were not inlined in #135. Running Clippy with a stable compiler fixes the problem.