### PR TITLE
Remove the scheduled build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "30 18 * * 5" # Every Friday at 18:30 UTC
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
GitHub disables a scheduled workflow if there has been no changes for some time (60 days). This makes the it counter-productive to have a schedule for this rarely updated repository.