### PR TITLE
Upgrade pulldown-cmark to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ contains_regex = ["regex", "semver"]
 
 [dependencies]
 proc-macro2 = { version = "1.0.36", default-features = false, features = ["span-locations"], optional = true }
-pulldown-cmark = { version = "0.9.1", default-features = false, optional = true }
+pulldown-cmark = { version = "0.11", default-features = false, optional = true }
 regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"], optional = true }
 semver = { version = "1.0.5", optional = true }
 syn = { version = "2.0.15", default-features = false, features = ["parsing", "printing", "full"], optional = true }

--- a/src/markdown_deps.rs
+++ b/src/markdown_deps.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "markdown_deps_updated")]
 use pulldown_cmark::CodeBlockKind::Fenced;
-use pulldown_cmark::{Event, Parser, Tag};
+use pulldown_cmark::{Event, Parser, Tag, TagEnd};
 use semver::{Version, VersionReq};
 use toml::Value;
 
@@ -78,7 +78,7 @@ fn find_toml_blocks(text: &str) -> Vec<CodeBlock> {
                     block.content.push_str(&code);
                 }
             }
-            Event::End(Tag::CodeBlock(_)) => {
+            Event::End(TagEnd::CodeBlock) => {
                 if let Some(block) = current_block.take() {
                     code_blocks.push(block);
                 }


### PR DESCRIPTION
This pull request upgrades `pulldown-cmark` to `0.11` so that other projects using newer `pulldown-cmark` can have one less dependency.